### PR TITLE
Convert new examId to testOpportunityId when legacy calls and remote …

### DIFF
--- a/proctor/src/main/java/TDS/Proctor/performance/dao/TestOpportunityExamMapDao.java
+++ b/proctor/src/main/java/TDS/Proctor/performance/dao/TestOpportunityExamMapDao.java
@@ -2,6 +2,16 @@ package TDS.Proctor.performance.dao;
 
 import java.util.UUID;
 
+/**
+ * Interacts with the table that stores mapping from test opportunity ID to exam ID
+ * This will eventually be removed as it won't be needed.
+ */
 public interface TestOpportunityExamMapDao {
+
+    /**
+     * Maps from the examID used in Proctor to the legacy test opportunity ID when running in dual mode
+     * @param examId examID form the exam.exam table
+     * @return the test opportunity ID mapped that corresponds to the examID
+     */
     UUID getTestOpportunityId(UUID examId);
 }

--- a/proctor/src/main/java/TDS/Proctor/performance/dao/TestOpportunityExamMapDao.java
+++ b/proctor/src/main/java/TDS/Proctor/performance/dao/TestOpportunityExamMapDao.java
@@ -1,0 +1,7 @@
+package TDS.Proctor.performance.dao;
+
+import java.util.UUID;
+
+public interface TestOpportunityExamMapDao {
+    UUID getTestOpportunityId(UUID examId);
+}

--- a/proctor/src/main/java/TDS/Proctor/performance/dao/impl/TestOpportunityExamMapDaoImpl.java
+++ b/proctor/src/main/java/TDS/Proctor/performance/dao/impl/TestOpportunityExamMapDaoImpl.java
@@ -1,0 +1,37 @@
+package TDS.Proctor.performance.dao.impl;
+
+import TDS.Proctor.performance.dao.TestOpportunityExamMapDao;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.util.UUID;
+
+import tds.dll.common.performance.caching.CacheType;
+
+@Repository
+public class TestOpportunityExamMapDaoImpl implements TestOpportunityExamMapDao {
+    private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private static final Logger logger = LoggerFactory.getLogger(TestSessionDaoImpl.class);
+
+    @Autowired
+    public void setDataSource(DataSource dataSource) {
+        this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+    }
+
+    @Override
+    @Cacheable(CacheType.MediumTerm)
+    public UUID getTestOpportunityId(UUID examId) {
+        final String SQL_QUERY = "select testopportunity_id from testopportunity_exam_map where exam_id = :examId";
+
+        MapSqlParameterSource parameters = new MapSqlParameterSource();
+        parameters.addValue("examId", examId.toString());
+
+        return UUID.fromString(namedParameterJdbcTemplate.queryForObject(SQL_QUERY, parameters, String.class));
+    }
+}

--- a/proctor/src/test/java/TDS/Proctor/services/RemoteTestOpportunityServiceTest.java
+++ b/proctor/src/test/java/TDS/Proctor/services/RemoteTestOpportunityServiceTest.java
@@ -4,6 +4,7 @@ import TDS.Proctor.Services.remote.RemoteTestOpportunityService;
 import TDS.Proctor.Sql.Data.Abstractions.AssessmentRepository;
 import TDS.Proctor.Sql.Data.Abstractions.ExamRepository;
 import TDS.Proctor.Sql.Data.Abstractions.ITestOpportunityService;
+import TDS.Proctor.performance.dao.TestOpportunityExamMapDao;
 import TDS.Shared.Exceptions.ReturnStatusException;
 import org.junit.After;
 import org.junit.Before;
@@ -35,9 +36,12 @@ public class RemoteTestOpportunityServiceTest {
     @Mock
     private AssessmentRepository mockAssessmentRepository;
 
+    @Mock
+    private TestOpportunityExamMapDao mockTestOpportunityExamMapDao;
+
     @Before
     public void setup() {
-        service = new RemoteTestOpportunityService(legacyTestOpportunityService, true, true, mockExamRepository, mockAssessmentRepository);
+        service = new RemoteTestOpportunityService(legacyTestOpportunityService, true, true, mockExamRepository, mockAssessmentRepository, mockTestOpportunityExamMapDao);
     }
 
     @After
@@ -94,55 +98,4 @@ public class RemoteTestOpportunityServiceTest {
         verify(legacyTestOpportunityService).approveAccommodations(examId, sessionId, proctorKey, browserKey, 0, accs);
         verify(mockExamRepository).approveAccommodations(isA(UUID.class), isA(ApproveAccommodationsRequest.class));
     }
-
-//    @Test
-//    public void shouldRetrieveExamsPendingApproval() throws Exception {
-//
-//        mockServer.expect(requestTo(containsString("pending-approval"))).andRespond(
-//            withSuccess(pendingExamsResponseBody, APPLICATION_JSON));
-//
-//        mockServer.expect(requestTo(containsString("assessments/accommodations"))).andRespond(
-//            withSuccess(assessmentAccommodations, APPLICATION_JSON));
-//
-//        mockServer.expect(requestTo(containsString("accommodations"))).andRespond(
-//            withSuccess(examAccommodations, APPLICATION_JSON));
-//
-//        TestOpps testsForApproval = remoteTestOpportunityService.getTestsForApproval(UUID.randomUUID(), new Random().nextLong(), UUID.randomUUID());
-//
-//        assertTrue(testsForApproval.size() == 1);
-//    }
-//
-//    @Test
-//    public void shouldRetrieveNoExamsPendingApproval() throws Exception {
-//        MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
-//
-//        mockServer.expect(anything()).andRespond(
-//            withSuccess(emptyResponseBody, APPLICATION_JSON));
-//
-//        TestOpps testsForApproval = remoteTestOpportunityService.getTestsForApproval(UUID.randomUUID(), new Random().nextLong(), UUID.randomUUID());
-//
-//        assertTrue(testsForApproval.size() == 0);
-//    }
-//
-//    @Test
-//    public void shouldApproveExam() throws Exception {
-//        MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
-//
-//        mockServer.expect(anything()).andRespond(
-//            withSuccess(emptyResponseBody, APPLICATION_JSON));
-//
-//        TestOpps testsForApproval = remoteTestOpportunityService.getTestsForApproval(UUID.randomUUID(), new Random().nextLong(), UUID.randomUUID());
-//
-//        assertTrue(testsForApproval.size() == 0);
-//    }
-//
-//    @Test
-//    public void shouldDenyExamWithoutException() throws Exception {
-//        MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
-//
-//        mockServer.expect(anything()).andRespond(
-//            withSuccess(emptyResponseBody, APPLICATION_JSON));
-//
-//        remoteTestOpportunityService.denyOpportunity(UUID.randomUUID(), UUID.randomUUID(), new Random().nextLong(), UUID.randomUUID(),"deny reason text");
-//    }
 }


### PR DESCRIPTION
…calls are being made

I followed the pattern of the performance code since this is in the legacy app and is fetching data from the existing session DB.  That is why you see the new DAO and int he performance package.