### PR TITLE
Get exams integration

### DIFF
--- a/proctor/src/main/java/TDS/Proctor/Services/remote/RemoteTestOpportunityService.java
+++ b/proctor/src/main/java/TDS/Proctor/Services/remote/RemoteTestOpportunityService.java
@@ -86,71 +86,6 @@ public class RemoteTestOpportunityService implements ITestOpportunityService {
         return testOpps;
     }
 
-    /* TestOpportunityRepository.java loadCurrentSessionTestees() */
-    private static TestOpps mapExpandableExamsToTestOpps(final List<ExpandableExam> exams) {
-        TestOpps testOpportunities = new TestOpps();
-
-        for (ExpandableExam expandableExam : exams) {
-            final Exam exam = expandableExam.getExam();
-            final String examStatus = exam.getStatus().getCode();
-            final int responseCount = expandableExam.getItemsResponseCount();
-
-            TestOpportunity opportunity = new TestOpportunity(exam.getId());
-            opportunity.setName(exam.getStudentName());
-            opportunity.setOpp(exam.getAttempts());
-            opportunity.setTestKey(exam.getAssessmentKey());
-            opportunity.setSsid(exam.getLoginSSID());
-            opportunity.setStatus(examStatus);
-            opportunity.setTestID(exam.getAssessmentId());
-            opportunity.setTestName(exam.getAssessmentId()); // In line
-            opportunity.setItemcount(exam.getMaxItems());
-            opportunity.setResponseCount(responseCount);
-            opportunity.setIsMsb(expandableExam.isMultiStageBraille());
-            opportunity.setRequestCount(expandableExam.getRequestCount());
-            opportunity.setAccs(buildAccommodationStringFromExamAccommodations(expandableExam.getExamAccommodations()));
-
-            final String pausedString = ExamStatusCode.STATUS_PAUSED.equals(examStatus)
-                ? String.format(", %s min", Minutes.minutesBetween(exam.getStatusChangedAt(), Instant.now()).getMinutes())
-                : StringUtils.EMPTY;
-
-            // Skip first conditional (g etScore() != null) - score is always null
-            if (exam.getCompletedAt() == null) {
-                opportunity.setDisplayStatus(String.format("%s, %d/%d%s", examStatus, responseCount, exam.getMaxItems(), pausedString));
-            } else {
-                opportunity.setDisplayStatus(examStatus);
-            }
-
-            opportunity.setCustAccs(exam.isCustomAccommodations());
-
-            testOpportunities.add(opportunity);
-        }
-
-        return testOpportunities;
-    }
-
-    private static String buildAccommodationStringFromExamAccommodations(final List<ExamAccommodation> examAccommodations) {
-        /* Accommodation String Syntax:
-            <accType1>: <accValue1> | <accType2>: <accValue2> | ...
-         */
-        StringBuilder builder = new StringBuilder();
-        ExamAccommodation examAccommodation;
-
-        for (int i = 0; i < examAccommodations.size(); ++i) {
-            examAccommodation = examAccommodations.get(i);
-            builder
-                .append(examAccommodation.getType())
-                .append(": ")
-                .append(examAccommodation.getValue());
-
-            // If this is not the last element, add a pipe delimiter
-            if (i != examAccommodations.size() - 1) {
-                builder.append(" | ");
-            }
-        }
-
-        return builder.toString();
-    }
-
     @Override
     public TestOpps getTestsForApproval(final UUID sessionId, final long proctorKey, final UUID browserKey) throws ReturnStatusException {
         TestOpps testOpps = null;
@@ -307,4 +242,70 @@ public class RemoteTestOpportunityService implements ITestOpportunityService {
 
         return testOpportunityExamMapDao.getTestOpportunityId(examId);
     }
+
+    /* TestOpportunityRepository.java loadCurrentSessionTestees() */
+    private static TestOpps mapExpandableExamsToTestOpps(final List<ExpandableExam> exams) {
+        TestOpps testOpportunities = new TestOpps();
+
+        for (ExpandableExam expandableExam : exams) {
+            final Exam exam = expandableExam.getExam();
+            final String examStatus = exam.getStatus().getCode();
+            final int responseCount = expandableExam.getItemsResponseCount();
+
+            TestOpportunity opportunity = new TestOpportunity(exam.getId());
+            opportunity.setName(exam.getStudentName());
+            opportunity.setOpp(exam.getAttempts());
+            opportunity.setTestKey(exam.getAssessmentKey());
+            opportunity.setSsid(exam.getLoginSSID());
+            opportunity.setStatus(examStatus);
+            opportunity.setTestID(exam.getAssessmentId());
+            opportunity.setTestName(exam.getAssessmentId()); // TestOpportunityRepository line 99 sets testName to testId
+            opportunity.setItemcount(exam.getMaxItems());
+            opportunity.setResponseCount(responseCount);
+            opportunity.setIsMsb(expandableExam.isMultiStageBraille());
+            opportunity.setRequestCount(expandableExam.getRequestCount());
+            opportunity.setAccs(buildAccommodationStringFromExamAccommodations(expandableExam.getExamAccommodations()));
+
+            final String pausedString = ExamStatusCode.STATUS_PAUSED.equals(examStatus)
+                ? String.format(", %s min", Minutes.minutesBetween(exam.getStatusChangedAt(), Instant.now()).getMinutes())
+                : StringUtils.EMPTY;
+
+            // Skip first conditional (getScore() != null) - score is always null
+            if (exam.getCompletedAt() == null) {
+                opportunity.setDisplayStatus(String.format("%s, %d/%d%s", examStatus, responseCount, exam.getMaxItems(), pausedString));
+            } else {
+                opportunity.setDisplayStatus(examStatus);
+            }
+
+            opportunity.setCustAccs(exam.isCustomAccommodations());
+
+            testOpportunities.add(opportunity);
+        }
+
+        return testOpportunities;
+    }
+
+    private static String buildAccommodationStringFromExamAccommodations(final List<ExamAccommodation> examAccommodations) {
+        /* Accommodation String Syntax:
+            <accType1>: <accValue1> | <accType2>: <accValue2> | ...
+         */
+        StringBuilder builder = new StringBuilder();
+        ExamAccommodation examAccommodation;
+
+        for (int i = 0; i < examAccommodations.size(); ++i) {
+            examAccommodation = examAccommodations.get(i);
+            builder
+                .append(examAccommodation.getType())
+                .append(": ")
+                .append(examAccommodation.getValue());
+
+            // If this is not the last element, add a pipe delimiter
+            if (i != examAccommodations.size() - 1) {
+                builder.append(" | ");
+            }
+        }
+
+        return builder.toString();
+    }
+
 }

--- a/proctor/src/main/java/TDS/Proctor/Services/remote/RemoteTestOpportunityService.java
+++ b/proctor/src/main/java/TDS/Proctor/Services/remote/RemoteTestOpportunityService.java
@@ -81,9 +81,7 @@ public class RemoteTestOpportunityService implements ITestOpportunityService {
             return testOpps;
         }
 
-        testOpps = mapExpandableExamsToTestOpps(examRepository.findExamsForSessionId(sessionId));
-
-        return testOpps;
+        return mapExpandableExamsToTestOpps(examRepository.findExamsForSessionId(sessionId));
     }
 
     @Override
@@ -266,12 +264,12 @@ public class RemoteTestOpportunityService implements ITestOpportunityService {
             opportunity.setRequestCount(expandableExam.getRequestCount());
             opportunity.setAccs(buildAccommodationStringFromExamAccommodations(expandableExam.getExamAccommodations()));
 
-            final String pausedString = ExamStatusCode.STATUS_PAUSED.equals(examStatus)
-                ? String.format(", %s min", Minutes.minutesBetween(exam.getStatusChangedAt(), Instant.now()).getMinutes())
-                : StringUtils.EMPTY;
-
             // Skip first conditional (getScore() != null) - score is always null
             if (exam.getCompletedAt() == null) {
+                final String pausedString = ExamStatusCode.STATUS_PAUSED.equals(examStatus)
+                    ? String.format(", %s min", Minutes.minutesBetween(exam.getStatusChangedAt(), Instant.now()).getMinutes())
+                    : StringUtils.EMPTY;
+
                 opportunity.setDisplayStatus(String.format("%s, %d/%d%s", examStatus, responseCount, exam.getMaxItems(), pausedString));
             } else {
                 opportunity.setDisplayStatus(examStatus);

--- a/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/ExamRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/ExamRepository.java
@@ -10,6 +10,7 @@ import tds.common.ValidationError;
 import tds.exam.ApproveAccommodationsRequest;
 import tds.exam.Exam;
 import tds.exam.ExamAccommodation;
+import tds.exam.ExpandableExam;
 
 /**
  * Repository to interact with exam data
@@ -52,4 +53,13 @@ public interface ExamRepository {
      * @throws ReturnStatusException
      */
     Optional<ValidationError> updateStatus(final UUID examId, final String status, final String stage, final String reason) throws ReturnStatusException;
+
+    /**
+     * Fetches a list of {@link tds.exam.ExpandableExam}s for the session
+     *
+     * @param sessionId the id of the session
+     * @return a list of exams for the session
+     * @throws ReturnStatusException
+     */
+    List<ExpandableExam> findExamsForSessionId(final UUID sessionId) throws ReturnStatusException;
 }

--- a/proctor/src/test/java/TDS/Proctor/services/RemoteTestOpportunityServiceTest.java
+++ b/proctor/src/test/java/TDS/Proctor/services/RemoteTestOpportunityServiceTest.java
@@ -4,8 +4,13 @@ import TDS.Proctor.Services.remote.RemoteTestOpportunityService;
 import TDS.Proctor.Sql.Data.Abstractions.AssessmentRepository;
 import TDS.Proctor.Sql.Data.Abstractions.ExamRepository;
 import TDS.Proctor.Sql.Data.Abstractions.ITestOpportunityService;
+import TDS.Proctor.Sql.Data.TestOpportunity;
+import TDS.Proctor.Sql.Data.TestOpps;
 import TDS.Proctor.performance.dao.TestOpportunityExamMapDao;
 import TDS.Shared.Exceptions.ReturnStatusException;
+import org.joda.time.DateTime;
+import org.joda.time.Instant;
+import org.joda.time.ReadableDuration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,12 +18,19 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Arrays;
 import java.util.UUID;
 
 import tds.exam.ApproveAccommodationsRequest;
+import tds.exam.Exam;
+import tds.exam.ExamAccommodation;
+import tds.exam.ExamStatusCode;
+import tds.exam.ExpandableExam;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static tds.exam.ExamStatusCode.STATUS_APPROVED;
 import static tds.exam.ExamStatusCode.STATUS_DENIED;
 import static tds.exam.ExamStatusStage.IN_USE;
@@ -97,5 +109,95 @@ public class RemoteTestOpportunityServiceTest {
 
         verify(legacyTestOpportunityService).approveAccommodations(examId, sessionId, proctorKey, browserKey, 0, accs);
         verify(mockExamRepository).approveAccommodations(isA(UUID.class), isA(ApproveAccommodationsRequest.class));
+    }
+
+    @Test
+    public void shouldReturnTestOppsListForSessionId() throws ReturnStatusException {
+        UUID sessionId = UUID.randomUUID();
+        // Exam 1
+        Exam exam = new Exam.Builder()
+            .withId(UUID.randomUUID())
+            .withStudentName("Student name1")
+            .withAttempts(2)
+            .withAssessmentKey("assessmentKey1")
+            .withAssessmentId("assessmentId1")
+            .withLoginSSID("LOGINSSID1")
+            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_STARTED), Instant.now())
+            .withMaxItems(4)
+            .withCustomAccommodation(false)
+            .build();
+        ExamAccommodation examAccommodation1 = new ExamAccommodation.Builder(UUID.randomUUID())
+            .withType("Type One")
+            .withValue("Accommodation Description 1 ")
+            .build();
+        ExamAccommodation examAccommodation2 = new ExamAccommodation.Builder(UUID.randomUUID())
+            .withType("Type Two")
+            .withValue("Accommodation Description 2")
+            .build();
+        ExpandableExam expandableExam1 = new ExpandableExam.Builder(exam)
+            .withItemsResponseCount(3)
+            .withMultiStageBraille(true)
+            .withRequestCount(7)
+            .withExamAccommodations(Arrays.asList(examAccommodation1, examAccommodation2))
+            .build();
+
+        Instant datePaused = DateTime.now().minusMinutes(5).toInstant();
+
+        // Exam 2
+        Exam pausedExam = new Exam.Builder()
+            .withId(UUID.randomUUID())
+            .withId(UUID.randomUUID())
+            .withStudentName("Student name2")
+            .withAttempts(0)
+            .withAssessmentKey("assessmentKey2")
+            .withAssessmentId("assessmentId2")
+            .withLoginSSID("LOGINSSID2")
+            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_PAUSED), datePaused)
+            .withMaxItems(4)
+            .withCustomAccommodation(false)
+            .build();
+        ExamAccommodation examAccommodation3 = new ExamAccommodation.Builder(UUID.randomUUID())
+            .withType("Type Three")
+            .withValue("Accommodation Description 3")
+            .build();
+        ExpandableExam pausedExpandaleExam = new ExpandableExam.Builder(pausedExam)
+            .withItemsResponseCount(4)
+            .withMultiStageBraille(false)
+            .withRequestCount(0)
+            .withExamAccommodations(Arrays.asList(examAccommodation3))
+            .build();
+
+        when(mockExamRepository.findExamsForSessionId(sessionId)).thenReturn(Arrays.asList(expandableExam1, pausedExpandaleExam));
+        TestOpps testOpps = service.getCurrentSessionTestees(sessionId, 1234, UUID.randomUUID());
+        assertThat(testOpps).hasSize(2);
+        TestOpportunity testOpp1 = testOpps.get(0);
+        assertThat(testOpp1.getName()).isEqualTo(exam.getStudentName());
+        assertThat(testOpp1.getOppKey()).isEqualTo(exam.getId());
+        assertThat(testOpp1.getOpp()).isEqualTo(exam.getAttempts());
+        assertThat(testOpp1.getDisplayStatus()).isEqualTo("started, 3/4");
+        assertThat(testOpp1.getItemcount()).isEqualTo(exam.getMaxItems());
+        assertThat(testOpp1.getRequestCount()).isEqualTo(expandableExam1.getRequestCount());
+        assertThat(testOpp1.isMsb()).isEqualTo(expandableExam1.isMultiStageBraille());
+        assertThat(testOpp1.getSsid()).isEqualTo(exam.getLoginSSID());
+        assertThat(testOpp1.getTestID()).isEqualTo(exam.getAssessmentId());
+        assertThat(testOpp1.getTestKey()).isEqualTo(exam.getAssessmentKey());
+        assertThat(testOpp1.getResponseCount()).isEqualTo(expandableExam1.getItemsResponseCount());
+        assertThat(testOpp1.getTestName()).isEqualTo(exam.getAssessmentId());
+        assertThat(testOpp1.getAccs()).isEqualTo("Type One: Accommodation Description 1  | Type Two: Accommodation Description 2");
+
+        TestOpportunity testOpp2 = testOpps.get(1);
+        assertThat(testOpp2.getName()).isEqualTo(pausedExam.getStudentName());
+        assertThat(testOpp2.getOppKey()).isEqualTo(pausedExam.getId());
+        assertThat(testOpp2.getOpp()).isEqualTo(pausedExam.getAttempts());
+        assertThat(testOpp2.getDisplayStatus()).isEqualTo(String.format("paused, 4/4, %s min", 5));
+        assertThat(testOpp2.getItemcount()).isEqualTo(pausedExam.getMaxItems());
+        assertThat(testOpp2.getRequestCount()).isEqualTo(pausedExpandaleExam.getRequestCount());
+        assertThat(testOpp2.isMsb()).isEqualTo(pausedExpandaleExam.isMultiStageBraille());
+        assertThat(testOpp2.getSsid()).isEqualTo(pausedExam.getLoginSSID());
+        assertThat(testOpp2.getTestID()).isEqualTo(pausedExam.getAssessmentId());
+        assertThat(testOpp2.getTestKey()).isEqualTo(pausedExam.getAssessmentKey());
+        assertThat(testOpp2.getResponseCount()).isEqualTo(pausedExpandaleExam.getItemsResponseCount());
+        assertThat(testOpp2.getTestName()).isEqualTo(pausedExam.getAssessmentId());
+        assertThat(testOpp2.getAccs()).isEqualTo("Type Three: Accommodation Description 3");
     }
 }

--- a/proctor/src/test/java/TDS/Proctor/sql/RemoteExamRepositoryTest.java
+++ b/proctor/src/test/java/TDS/Proctor/sql/RemoteExamRepositoryTest.java
@@ -18,15 +18,19 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 import tds.exam.Exam;
 import tds.exam.ExamAccommodation;
+import tds.exam.ExpandableExam;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -78,6 +82,41 @@ public class RemoteExamRepositoryTest {
             .thenReturn(responseEntity);
 
         assertThat(remoteExamRepository.findAllAccommodations(examAccommodation.getExamId())).isEqualTo(accommodations);
+    }
+
+    @Test
+    public void shouldReturnExamsForSessionId() throws ReturnStatusException {
+        Exam exam1 = new Exam.Builder().withId(UUID.randomUUID()).build();
+        Exam exam2 = new Exam.Builder().withId(UUID.randomUUID()).build();
+        ExpandableExam expandableExam1 = new ExpandableExam.Builder(exam1).build();
+        ExpandableExam expandableExam2 = new ExpandableExam.Builder(exam2).build();
+
+        when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+            .thenReturn(new ResponseEntity(Arrays.asList(expandableExam1, expandableExam2), HttpStatus.OK));
+
+        List<ExpandableExam> expandableExams = remoteExamRepository.findExamsForSessionId(UUID.randomUUID());
+
+        verify(mockRestTemplate).exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class));
+        assertThat(expandableExams).hasSize(2);
+        assertThat(expandableExams.get(0).getExam().getId()).isEqualTo(exam1.getId());
+        assertThat(expandableExams.get(1).getExam().getId()).isEqualTo(exam2.getId());
+    }
+
+    @Test
+    public void shouldReturnEmptyListWithNoContent() throws ReturnStatusException {
+        when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+            .thenReturn(new ResponseEntity(new ArrayList<ExpandableExam>(), HttpStatus.NO_CONTENT));
+
+        List<ExpandableExam> expandableExams = remoteExamRepository.findExamsForSessionId(UUID.randomUUID());
+        verify(mockRestTemplate).exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class));
+        assertThat(expandableExams).isEmpty();
+    }
+
+    @Test (expected = ReturnStatusException.class)
+    public void shouldThrowReturnStatusExceptionWhenRestClientUnhandledExceptionIsThrownFindExamsForSession() throws ReturnStatusException {
+        when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+            .thenThrow(new RestClientException("Fail"));
+        remoteExamRepository.findExamsForSessionId(UUID.randomUUID());
     }
 }
 


### PR DESCRIPTION
This PR includes the implementation of RemoteTestOpportunityService.getCurrentSessionTestees().

Ultimately the goal of this code is to fetch a list of "ExpandableExams" containing item response, exam accommodation, MSB, and other data, and to populate a "TestOpps" view model that the UI will consume.

The primary legacy entry point of the code that is being ported is TestOpportunityService.getCurrentSessionTestees(). This method calls TestOpportunityRepository.getCurrentSessionTestees() which then maps the queried data into a "TestOpps" model object.