### PR TITLE
Proctor print request integration

### DIFF
--- a/proctor/pom.xml
+++ b/proctor/pom.xml
@@ -20,7 +20,7 @@
 		<sb11-shared-code.version>3.0.0</sb11-shared-code.version>
 		<sb11-shared-security.version>3.0.0</sb11-shared-security.version>
 		<org.springframework.security-version>3.2.4.RELEASE</org.springframework.security-version>
-		<tds-exam-client.version>0.0.2</tds-exam-client.version>
+		<tds-exam-client.version>0.0.3</tds-exam-client.version>
 		<tds-assessment-client.version>0.0.2</tds-assessment-client.version>
 		<tds-session-client.version>0.0.3</tds-session-client.version>
 		<jackson.version>2.8.5</jackson.version>

--- a/proctor/pom.xml
+++ b/proctor/pom.xml
@@ -20,7 +20,7 @@
 		<sb11-shared-code.version>3.0.0</sb11-shared-code.version>
 		<sb11-shared-security.version>3.0.0</sb11-shared-security.version>
 		<org.springframework.security-version>3.2.4.RELEASE</org.springframework.security-version>
-		<tds-exam-client.version>0.0.1</tds-exam-client.version>
+		<tds-exam-client.version>0.0.2</tds-exam-client.version>
 		<tds-assessment-client.version>0.0.2</tds-assessment-client.version>
 		<tds-session-client.version>0.0.3</tds-session-client.version>
 		<jackson.version>2.8.5</jackson.version>

--- a/proctor/src/main/java/TDS/Proctor/Services/remote/RemoteTesteeRequestService.java
+++ b/proctor/src/main/java/TDS/Proctor/Services/remote/RemoteTesteeRequestService.java
@@ -6,7 +6,6 @@ import TDS.Proctor.Sql.Data.Abstractions.ITesteeRequestService;
 import TDS.Proctor.Sql.Data.TesteeRequest;
 import TDS.Proctor.Sql.Data.TesteeRequests;
 import TDS.Proctor.performance.dao.ProctorUserDao;
-import TDS.Proctor.performance.dao.TestOpportunityExamMapDao;
 import TDS.Shared.Exceptions.ReturnStatusException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;

--- a/proctor/src/main/java/TDS/Proctor/Services/remote/RemoteTesteeRequestService.java
+++ b/proctor/src/main/java/TDS/Proctor/Services/remote/RemoteTesteeRequestService.java
@@ -1,0 +1,166 @@
+package TDS.Proctor.Services.remote;
+
+import TDS.Proctor.Sql.Data.Abstractions.ExamPrintRequestRepository;
+import TDS.Proctor.Sql.Data.Abstractions.ITesteeRequestService;
+import TDS.Proctor.Sql.Data.TesteeRequest;
+import TDS.Proctor.Sql.Data.TesteeRequests;
+import TDS.Proctor.performance.dao.ProctorUserDao;
+import TDS.Proctor.performance.dao.TestOpportunityExamMapDao;
+import TDS.Shared.Exceptions.ReturnStatusException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.List;
+import java.util.UUID;
+
+import tds.exam.ExamPrintRequest;
+
+public class RemoteTesteeRequestService implements ITesteeRequestService {
+    private final ITesteeRequestService legacyTesteeRequestService;
+    private final ExamPrintRequestRepository examPrintRequestRepository;
+    private final ProctorUserDao proctorUserDao;
+    private final TestOpportunityExamMapDao testOpportunityExamMapDao;
+    private final boolean isLegacyCallsEnabled;
+    private final boolean isRemoteCallsEnabled;
+
+    @Autowired
+    public RemoteTesteeRequestService(final ITesteeRequestService testeeRequestService,
+                                      final ExamPrintRequestRepository examPrintRequestRepository,
+                                      @Value("${tds.exam.legacy.enabled}") final boolean isLegacyCallsEnabled,
+                                      @Value("${tds.exam.remote.enabled}") final boolean isRemoteCallsEnabled,
+                                      final TestOpportunityExamMapDao testOpportunityExamMapDao,
+                                      final ProctorUserDao proctorUserDao) {
+        this.legacyTesteeRequestService = testeeRequestService;
+        this.examPrintRequestRepository = examPrintRequestRepository;
+        this.isLegacyCallsEnabled = isLegacyCallsEnabled;
+        this.isRemoteCallsEnabled = isRemoteCallsEnabled;
+        this.proctorUserDao = proctorUserDao;
+        this.testOpportunityExamMapDao = testOpportunityExamMapDao;
+    }
+
+    @Override
+    public TesteeRequests getCurrentTesteeRequests(final UUID opportunityKey, final UUID sessionKey, final long proctorKey, final UUID browserKey) throws ReturnStatusException {
+        TesteeRequests requests = null;
+
+        if (isLegacyCallsEnabled) {
+            requests = legacyTesteeRequestService.getCurrentTesteeRequests(opportunityKey, sessionKey, proctorKey, browserKey);
+        }
+
+        if (!isRemoteCallsEnabled) {
+            return requests;
+        }
+
+        final String accessDenied = proctorUserDao.validateProctorSession(proctorKey, sessionKey, browserKey);
+
+        if (accessDenied != null) {
+            throw new ReturnStatusException(accessDenied);
+        }
+
+        return mapPrintRequestsToTesteeRequests(examPrintRequestRepository.findUnfulfilledRequests(opportunityKey, sessionKey));
+    }
+
+    @Override
+    public TesteeRequests getApprovedTesteeRequests(final UUID sessionKey, final long proctorKey, final UUID browserKey) throws ReturnStatusException {
+        TesteeRequests requests = null;
+
+        if (isLegacyCallsEnabled) {
+            requests = legacyTesteeRequestService.getApprovedTesteeRequests(sessionKey, proctorKey, browserKey);
+        }
+
+        if (!isRemoteCallsEnabled) {
+            return requests;
+        }
+
+        final String accessDenied = proctorUserDao.validateProctorSession(proctorKey, sessionKey, browserKey);
+
+        if (accessDenied != null) {
+            throw new ReturnStatusException(accessDenied);
+        }
+
+        return mapPrintRequestsToTesteeRequests(examPrintRequestRepository.findApprovedRequests(sessionKey));
+    }
+
+    @Override
+    public TesteeRequest getTesteeRequestValues(final UUID sessionKey, final long proctorKey, final UUID browserKey, final UUID requestKey, final boolean markFulfilled) throws ReturnStatusException {
+        TesteeRequest testeeRequest = null;
+
+        if (isLegacyCallsEnabled) {
+            testeeRequest = legacyTesteeRequestService.getTesteeRequestValues(sessionKey, proctorKey, browserKey, requestKey, markFulfilled);
+        }
+
+        if (!isRemoteCallsEnabled) {
+            return testeeRequest;
+        }
+
+        final String accessDenied = proctorUserDao.validateProctorSession(proctorKey, sessionKey, browserKey);
+
+        if (accessDenied != null) {
+            throw new ReturnStatusException(accessDenied);
+        }
+
+        // markFulfilled is always "true" as used in the legacy app
+        return mapPrintRequestToTesteeRequest(examPrintRequestRepository.findRequestAndApprove(requestKey));
+    }
+
+    @Override
+    public boolean denyTesteeRequest(final UUID sessionKey, final long proctorKey, final UUID browserKey, final UUID requestKey, final String reason) throws ReturnStatusException {
+        boolean successful = false;
+
+        if (isLegacyCallsEnabled) {
+            successful = legacyTesteeRequestService.denyTesteeRequest(sessionKey, proctorKey, browserKey, requestKey, reason);
+        }
+
+        if (!isRemoteCallsEnabled) {
+            return successful;
+        }
+
+        final String accessDenied = proctorUserDao.validateProctorSession(proctorKey, sessionKey, browserKey);
+
+        if (accessDenied != null) {
+            throw new ReturnStatusException(accessDenied);
+        }
+
+        examPrintRequestRepository.denyPrintRequest(requestKey, reason);
+
+        return true;
+    }
+
+    @Override
+    public void convertDates(final TesteeRequests testeeRequests, final int timeZoneOffset) {
+        legacyTesteeRequestService.convertDates(testeeRequests, timeZoneOffset);
+    }
+
+    /* Port of TesteeRequestRepository.loadTesteeRequests() */
+    private TesteeRequests mapPrintRequestsToTesteeRequests(final List<ExamPrintRequest> printRequests) {
+        TesteeRequests testeeRequests = new TesteeRequests();
+
+        for (ExamPrintRequest printRequest : printRequests) {
+            TesteeRequest testeeRequest = mapPrintRequestToTesteeRequest(printRequest);
+            testeeRequests.add(testeeRequest);
+        }
+
+        return testeeRequests;
+    }
+
+    private TesteeRequest mapPrintRequestToTesteeRequest(final ExamPrintRequest printRequest) {
+        TesteeRequest testeeRequest = new TesteeRequest();
+        testeeRequest.setKey(printRequest.getId());
+        testeeRequest.setOppKey(printRequest.getExamId());
+        testeeRequest.setSessionKey(printRequest.getSessionId());
+        testeeRequest.setRequestType(printRequest.getType());
+        testeeRequest.setRequestValue(printRequest.getValue());
+        testeeRequest.setDateSubmitted(printRequest.getCreatedAt().toDate());
+
+        if (printRequest.getDeniedAt() != null) {
+            testeeRequest.setDateFulfilled(printRequest.getDeniedAt().toDate());
+            testeeRequest.setDeniedReason(printRequest.getReasonDenied());
+        } else if (printRequest.getApprovedAt() != null) {
+            testeeRequest.setDateFulfilled(printRequest.getApprovedAt().toDate());
+        }
+
+        testeeRequest.setItemPage(printRequest.getPagePosition());
+        testeeRequest.setItemPosition(printRequest.getItemPosition());
+        testeeRequest.setRequestDesc(printRequest.getDescription());
+        return testeeRequest;
+    }
+}

--- a/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/ExamPrintRequestRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/ExamPrintRequestRepository.java
@@ -11,11 +11,40 @@ import tds.exam.ExamPrintRequest;
  * Repository to interact with exam print request data
  */
 public interface ExamPrintRequestRepository {
+    /**
+     * Fetches a list of unfulfilled {@link tds.exam.ExamPrintRequest}s
+     *
+     * @param examId    The id of the exam the {@link tds.exam.ExamPrintRequest}s belong to
+     * @param sessionId The id of the session the {@link tds.exam.ExamPrintRequest}s belong to
+     * @return A {@link List<tds.exam.ExamPrintRequest>} of unfulfilled requests ordered by ExamIds and submission time
+     * @throws ReturnStatusException
+     */
     List<ExamPrintRequest> findUnfulfilledRequests(final UUID examId, final UUID sessionId) throws ReturnStatusException;
 
+    /**
+     * Creates a request to deny an {@link tds.exam.ExamPrintRequest}
+     *
+     * @param requestId The id of the {@link tds.exam.ExamPrintRequest} to deny
+     * @param reason    The reason the {@link tds.exam.ExamPrintRequest} is being denied
+     * @throws ReturnStatusException
+     */
     void denyPrintRequest(final UUID requestId, final String reason) throws ReturnStatusException;
 
+    /**
+     * Marks an {@link tds.exam.ExamPrintRequest} as approved and fetches the updated request
+     *
+     * @param requestId The id of the {@link tds.exam.ExamPrintRequest} to approve
+     * @return The approved {@link tds.exam.ExamPrintRequest}
+     * @throws ReturnStatusException
+     */
     ExamPrintRequest findRequestAndApprove(final UUID requestId) throws ReturnStatusException;
 
+    /**
+     * Creates a request to fetch a list of approved {@link tds.exam.ExamPrintRequest} for the specified session
+     *
+     * @param sessionId The id of the session to fetch approved {@link tds.exam.ExamPrintRequest} for
+     * @return The list of approved {@link tds.exam.ExamPrintRequest} for the session
+     * @throws ReturnStatusException
+     */
     List<ExamPrintRequest> findApprovedRequests(final UUID sessionId) throws ReturnStatusException;
 }

--- a/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/ExamPrintRequestRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/ExamPrintRequestRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.UUID;
 
 import tds.exam.ExamPrintRequest;
+import tds.exam.ExpandableExamPrintRequest;
 
 /**
  * Repository to interact with exam print request data
@@ -37,7 +38,7 @@ public interface ExamPrintRequestRepository {
      * @return The approved {@link tds.exam.ExamPrintRequest}
      * @throws ReturnStatusException
      */
-    ExamPrintRequest findRequestAndApprove(final UUID requestId) throws ReturnStatusException;
+    ExpandableExamPrintRequest findRequestAndApprove(final UUID requestId) throws ReturnStatusException;
 
     /**
      * Creates a request to fetch a list of approved {@link tds.exam.ExamPrintRequest} for the specified session

--- a/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/ExamPrintRequestRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/ExamPrintRequestRepository.java
@@ -1,0 +1,21 @@
+package TDS.Proctor.Sql.Data.Abstractions;
+
+import TDS.Shared.Exceptions.ReturnStatusException;
+
+import java.util.List;
+import java.util.UUID;
+
+import tds.exam.ExamPrintRequest;
+
+/**
+ * Repository to interact with exam print request data
+ */
+public interface ExamPrintRequestRepository {
+    List<ExamPrintRequest> findUnfulfilledRequests(final UUID examId, final UUID sessionId) throws ReturnStatusException;
+
+    void denyPrintRequest(final UUID requestId, final String reason) throws ReturnStatusException;
+
+    ExamPrintRequest findRequestAndApprove(final UUID requestId) throws ReturnStatusException;
+
+    List<ExamPrintRequest> findApprovedRequests(final UUID sessionId) throws ReturnStatusException;
+}

--- a/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/ExamRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/ExamRepository.java
@@ -17,12 +17,21 @@ import tds.exam.ExpandableExam;
  */
 public interface ExamRepository {
     /**
+     * Fetches an {@link tds.exam.Exam} by its id
+     *
+     * @param id The id of the {@link tds.exam.Exam} to fetch
+     * @return The fetched {@link tds.exam.Exam}
+     */
+    Exam getExamById(final UUID id) throws ReturnStatusExceptions;
+
+    /**
      * Fetches all exams pending approval for a specific session
+     *
      * @param sessionId the id of the session
      * @return the list of {@link tds.exam.Exam}s pending approval
      * @throws ReturnStatusException
      */
-    List<Exam> findExamsPendingApproval(UUID sessionId) throws ReturnStatusException;
+    List<Exam> findExamsPendingApproval(final UUID sessionId) throws ReturnStatusException;
 
     /**
      * Fetches the collection of {@link tds.exam.ExamAccommodation}s for an exam
@@ -31,7 +40,7 @@ public interface ExamRepository {
      * @return the list of {@link tds.exam.ExamAccommodation}s
      * @throws ReturnStatusException
      */
-    List<ExamAccommodation> findAllAccommodations(UUID examId) throws ReturnStatusException;
+    List<ExamAccommodation> findAllAccommodations(final UUID examId) throws ReturnStatusException;
 
     /**
      * Creates a request for the exam service to approve {@link tds.exam.ExamAccommodation}s
@@ -47,7 +56,7 @@ public interface ExamRepository {
      *
      * @param examId the id of the {@link tds.exam.Exam}
      * @param status the status to update the exam to
-     * @param stage the stage of the exam
+     * @param stage  the stage of the exam
      * @param reason the reason for the exam status update
      * @return An optional {@link tds.common.ValidationError}, if one occurs during the processing of the request
      * @throws ReturnStatusException

--- a/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/ExamRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/ExamRepository.java
@@ -22,7 +22,7 @@ public interface ExamRepository {
      * @param id The id of the {@link tds.exam.Exam} to fetch
      * @return The fetched {@link tds.exam.Exam}
      */
-    Exam getExamById(final UUID id) throws ReturnStatusExceptions;
+    Exam getExamById(final UUID id) throws ReturnStatusException;
 
     /**
      * Fetches all exams pending approval for a specific session

--- a/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/ExamRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/ExamRepository.java
@@ -17,14 +17,6 @@ import tds.exam.ExpandableExam;
  */
 public interface ExamRepository {
     /**
-     * Fetches an {@link tds.exam.Exam} by its id
-     *
-     * @param id The id of the {@link tds.exam.Exam} to fetch
-     * @return The fetched {@link tds.exam.Exam}
-     */
-    Exam getExamById(final UUID id) throws ReturnStatusException;
-
-    /**
      * Fetches all exams pending approval for a specific session
      *
      * @param sessionId the id of the session

--- a/proctor/src/main/java/TDS/Proctor/Sql/Repository/RemoteExamPrintRequestRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Repository/RemoteExamPrintRequestRepository.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.UUID;
 
 import tds.exam.ExamPrintRequest;
+import tds.exam.ExpandableExamPrintRequest;
 
 @Repository
 public class RemoteExamPrintRequestRepository implements ExamPrintRequestRepository {
@@ -77,21 +78,21 @@ public class RemoteExamPrintRequestRepository implements ExamPrintRequestReposit
     }
 
     @Override
-    public ExamPrintRequest findRequestAndApprove(final UUID requestId) throws ReturnStatusException {
+    public ExpandableExamPrintRequest findRequestAndApprove(final UUID requestId) throws ReturnStatusException {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
-        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/print/approve/%s", examUrl, requestId));
-
-        ExamPrintRequest examPrintRequestResponseEntity;
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/print/approve/%s", examUrl, requestId))
+            .queryParam("embed", ExpandableExamPrintRequest.EXPANDABLE_PARAMS_PRINT_REQUEST_WITH_EXAM);
+        ExpandableExamPrintRequest examPrintRequestResponseEntity;
 
         try {
             examPrintRequestResponseEntity = restTemplate.exchange(
                 builder.build().toUri(),
                 HttpMethod.PUT,
                 requestHttpEntity,
-                new ParameterizedTypeReference<ExamPrintRequest>() {
+                new ParameterizedTypeReference<ExpandableExamPrintRequest>() {
                 }).getBody();
         } catch (RestClientException rce) {
             throw new ReturnStatusException(rce);

--- a/proctor/src/main/java/TDS/Proctor/Sql/Repository/RemoteExamPrintRequestRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Repository/RemoteExamPrintRequestRepository.java
@@ -1,0 +1,126 @@
+package TDS.Proctor.Sql.Repository;
+
+import TDS.Proctor.Sql.Data.Abstractions.ExamPrintRequestRepository;
+import TDS.Shared.Exceptions.ReturnStatusException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+import java.util.UUID;
+
+import tds.common.web.resources.NoContentResponseResource;
+import tds.exam.ExamPrintRequest;
+
+@Repository
+public class RemoteExamPrintRequestRepository implements ExamPrintRequestRepository {
+    private final RestTemplate restTemplate;
+    private final String examUrl;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public RemoteExamPrintRequestRepository(@Qualifier("integrationRestTemplate") final RestTemplate restTemplate,
+                                @Value("${tds.exam.remote.url}") final String examUrl,
+                                @Qualifier("integrationObjectMapper") final ObjectMapper objectMapper) {
+        this.restTemplate = restTemplate;
+        this.examUrl = examUrl;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<ExamPrintRequest> findUnfulfilledRequests(final UUID examId, final UUID sessionId) throws ReturnStatusException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/print/%s/%s", examUrl, sessionId, examId));
+
+        try {
+            return restTemplate.exchange(
+                builder.build().toUri(),
+                HttpMethod.GET,
+                requestHttpEntity,
+                new ParameterizedTypeReference<List<ExamPrintRequest>>() {
+                }).getBody();
+        } catch (RestClientException rce) {
+            throw new ReturnStatusException(rce);
+        }
+    }
+
+    @Override
+    public void denyPrintRequest(final UUID requestId, final String reason) throws ReturnStatusException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<?> requestHttpEntity = new HttpEntity<>(reason, headers);
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/print/deny/%s", examUrl, requestId));
+
+        try {
+            restTemplate.exchange(
+                builder.build().toUri(),
+                HttpMethod.PUT,
+                requestHttpEntity,
+                new ParameterizedTypeReference<NoContentResponseResource>() {
+                }).getBody();
+        } catch (RestClientException rce) {
+            throw new ReturnStatusException(rce);
+        }
+    }
+
+    @Override
+    public ExamPrintRequest findRequestAndApprove(final UUID requestId) throws ReturnStatusException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/print/approve/%s", examUrl, requestId));
+
+        ExamPrintRequest examPrintRequestResponseEntity;
+
+        try {
+            examPrintRequestResponseEntity = restTemplate.exchange(
+                builder.build().toUri(),
+                HttpMethod.PUT,
+                requestHttpEntity,
+                new ParameterizedTypeReference<ExamPrintRequest>() {
+                }).getBody();
+        } catch (RestClientException rce) {
+            throw new ReturnStatusException(rce);
+        }
+
+        return examPrintRequestResponseEntity;
+    }
+
+    @Override
+    public List<ExamPrintRequest> findApprovedRequests(final UUID sessionId) throws ReturnStatusException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/print/approved/%s", examUrl, sessionId));
+
+        try {
+            return restTemplate.exchange(
+                builder.build().toUri(),
+                HttpMethod.GET,
+                requestHttpEntity,
+                new ParameterizedTypeReference<List<ExamPrintRequest>>() {
+                }).getBody();
+        } catch (RestClientException rce) {
+            throw new ReturnStatusException(rce);
+        }
+    }
+}

--- a/proctor/src/main/java/TDS/Proctor/Sql/Repository/RemoteExamPrintRequestRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Repository/RemoteExamPrintRequestRepository.java
@@ -11,7 +11,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -20,7 +19,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.util.List;
 import java.util.UUID;
 
-import tds.common.web.resources.NoContentResponseResource;
 import tds.exam.ExamPrintRequest;
 
 @Repository
@@ -31,8 +29,8 @@ public class RemoteExamPrintRequestRepository implements ExamPrintRequestReposit
 
     @Autowired
     public RemoteExamPrintRequestRepository(@Qualifier("integrationRestTemplate") final RestTemplate restTemplate,
-                                @Value("${tds.exam.remote.url}") final String examUrl,
-                                @Qualifier("integrationObjectMapper") final ObjectMapper objectMapper) {
+                                            @Value("${tds.exam.remote.url}") final String examUrl,
+                                            @Qualifier("integrationObjectMapper") final ObjectMapper objectMapper) {
         this.restTemplate = restTemplate;
         this.examUrl = examUrl;
         this.objectMapper = objectMapper;
@@ -72,8 +70,7 @@ public class RemoteExamPrintRequestRepository implements ExamPrintRequestReposit
                 builder.build().toUri(),
                 HttpMethod.PUT,
                 requestHttpEntity,
-                new ParameterizedTypeReference<NoContentResponseResource>() {
-                }).getBody();
+                Void.class);
         } catch (RestClientException rce) {
             throw new ReturnStatusException(rce);
         }

--- a/proctor/src/main/java/TDS/Proctor/Sql/Repository/RemoteExamRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Repository/RemoteExamRepository.java
@@ -50,27 +50,6 @@ public class RemoteExamRepository implements ExamRepository {
     }
 
     @Override
-    public Exam getExamById(final UUID id) throws ReturnStatusException {
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
-
-        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/%s", examUrl, id));
-
-        try {
-            return restTemplate.exchange(
-                builder.build().encode().toUri(),
-                HttpMethod.GET,
-                requestHttpEntity,
-                new ParameterizedTypeReference<Exam>() {
-                }).getBody();
-        } catch (RestClientException rce) {
-            throw new ReturnStatusException(rce);
-        }
-    }
-
-    @Override
     public List<Exam> findExamsPendingApproval(final UUID sessionId) throws ReturnStatusException {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);

--- a/proctor/src/main/java/TDS/Proctor/Sql/Repository/RemoteExamRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Repository/RemoteExamRepository.java
@@ -160,7 +160,8 @@ public class RemoteExamRepository implements ExamRepository {
             .queryParam("statusNot", ExamStatusCode.STATUS_DENIED)
             .queryParam("statusNot", ExamStatusCode.STATUS_PENDING)
             .queryParam("embed", ExpandableExam.EXPANDABLE_PARAMS_EXAM_ACCOMMODATIONS)
-            .queryParam("embed", ExpandableExam.EXPANDABLE_PARAMS_ITEM_RESPONSE_COUNT);
+            .queryParam("embed", ExpandableExam.EXPANDABLE_PARAMS_ITEM_RESPONSE_COUNT)
+            .queryParam("embed", ExpandableExam.EXPANDABLE_PARAMS_UNFULFILLED_REQUEST_COUNT);
 
         try {
             ResponseEntity<List<ExpandableExam>> response = restTemplate.exchange(

--- a/proctor/src/main/java/TDS/Proctor/Sql/Repository/RemoteExamRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Repository/RemoteExamRepository.java
@@ -49,6 +49,27 @@ public class RemoteExamRepository implements ExamRepository {
     }
 
     @Override
+    public Exam getExamById(final UUID id) throws ReturnStatusException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/%s", examUrl, id));
+
+        try {
+            return restTemplate.exchange(
+                builder.build().encode().toUri(),
+                HttpMethod.GET,
+                requestHttpEntity,
+                new ParameterizedTypeReference<Exam>() {
+                }).getBody();
+        } catch (RestClientException rce) {
+            throw new ReturnStatusException(rce);
+        }
+    }
+
+    @Override
     public List<Exam> findExamsPendingApproval(UUID sessionId) throws ReturnStatusException {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);

--- a/proctor/src/main/java/TDS/Proctor/performance/dao/TestOpportunityExamMapDao.java
+++ b/proctor/src/main/java/TDS/Proctor/performance/dao/TestOpportunityExamMapDao.java
@@ -14,4 +14,11 @@ public interface TestOpportunityExamMapDao {
      * @return the test opportunity ID mapped that corresponds to the examID
      */
     UUID getTestOpportunityId(UUID examId);
+
+    /**
+     * Maps from the legacy test opportunity id used in Proctor to the exam ID when running in dual mode
+     * @param testOpportunityId testOpportunity key from the session.testopportunity table
+     * @return the examId mapped that corresponds to the test opportunity ID
+     */
+    UUID getExamId(UUID testOpportunityId);
 }

--- a/proctor/src/main/java/TDS/Proctor/performance/dao/impl/TestOpportunityExamMapDaoImpl.java
+++ b/proctor/src/main/java/TDS/Proctor/performance/dao/impl/TestOpportunityExamMapDaoImpl.java
@@ -34,4 +34,14 @@ public class TestOpportunityExamMapDaoImpl implements TestOpportunityExamMapDao 
 
         return UUID.fromString(namedParameterJdbcTemplate.queryForObject(SQL_QUERY, parameters, String.class));
     }
+
+    @Override
+    public UUID getExamId(final UUID testOpportunityId) {
+        final String SQL_QUERY = "select exam_id from testopportunity_exam_map where testopportunity_id = :testOpportunityId";
+
+        MapSqlParameterSource parameters = new MapSqlParameterSource();
+        parameters.addValue("testOpportunityId", testOpportunityId.toString());
+
+        return UUID.fromString(namedParameterJdbcTemplate.queryForObject(SQL_QUERY, parameters, String.class));
+    }
 }

--- a/proctor/src/main/resources/context-modules/services-context-module.xml
+++ b/proctor/src/main/resources/context-modules/services-context-module.xml
@@ -43,17 +43,13 @@
 		<constructor-arg ref="tdsSettings"/>
      	<constructor-arg ref="iTestRepository"/>
 	</bean>
-	<bean id="iTestSessionService" class="TDS.Proctor.Services.TestSessionService" scope="prototype">
-		<constructor-arg ref="tdsSettings"/>
-		<constructor-arg ref="iTestSessionRepository"/>
-	</bean>
+	
 	<bean id="iMessageService" class="TDS.Proctor.Services.MessageService" scope="prototype">
      	<constructor-arg ref="iMessageRepository"/>
 	</bean>	
 	
 	<bean id="proctorAppTasks" class="TDS.Proctor.Services.ProctorAppTasks" scope="prototype">
 		<property name="appConfigTasks"><ref bean="iAppConfigService"/></property>
-		<property name="testSessionTasks"><ref bean="iTestSessionService"/></property>
 		<property name="testOppTasks"><ref bean="iTestOpportunityService"/></property>
      	<property name="testTasks"><ref bean="iTestService"/></property>
      	<property name="alertTasks"><ref bean="iAlertMessageService"/></property>

--- a/proctor/src/main/resources/context-modules/services-context-module.xml
+++ b/proctor/src/main/resources/context-modules/services-context-module.xml
@@ -21,7 +21,7 @@
 		<constructor-arg ref="tdsSettings"/>
      	<constructor-arg ref="iProctorRepository"/>
 	</bean>	
-	<bean id="iTesteeRequestService" class="TDS.Proctor.Services.TesteeRequestService" scope="prototype">
+	<bean id="legacyTesteeRequestService" class="TDS.Proctor.Services.TesteeRequestService" scope="prototype">
 		<constructor-arg ref="tdsSettings"/>
      	<constructor-arg ref="iTesteeRequestRepository"/>
 	</bean>	
@@ -34,7 +34,9 @@
 		<constructor-arg ref="iTestOpportunityRepository"/>
 	</bean>
 	<bean id="examRepository" class="TDS.Proctor.Sql.Repository.RemoteExamRepository" scope="prototype"></bean>
+	<bean id="examPrintRequestRepository" class="TDS.Proctor.Sql.Repository.RemoteExamPrintRequestRepository" scope="prototype"></bean>
 	<bean id="assessmentRepository" class="TDS.Proctor.Sql.Repository.RemoteAssessmentRepository" scope="prototype"></bean>
+	<bean id="iTesteeRequestService" class="TDS.Proctor.Services.remote.RemoteTesteeRequestService" scope="prototype"></bean>
 	<bean id="iTestOpportunityService" class="TDS.Proctor.Services.remote.RemoteTestOpportunityService" scope="prototype">	</bean>
 	<bean id="iTestService" class="TDS.Proctor.Services.TestService" scope="prototype">
 		<constructor-arg ref="tdsSettings"/>

--- a/proctor/src/main/resources/context-modules/services-context-module.xml
+++ b/proctor/src/main/resources/context-modules/services-context-module.xml
@@ -7,12 +7,12 @@
 	<bean id="iAlertMessageService" class="TDS.Proctor.Services.AlertMessageService" scope="prototype">
 		<constructor-arg ref="tdsSettings"/>
      	<constructor-arg ref="iAlertMessageRepository"/>
-	</bean>	
+	</bean>
 	<bean id="iAppConfigService" class="TDS.Proctor.Services.AppConfigService" scope="prototype">
 		<constructor-arg ref="tdsSettings"/>
      	<constructor-arg ref="iAppConfigRepository"/>
      	<constructor-arg ref="clientContextBrowserValidation"/>
-	</bean>	
+	</bean>
 	<bean id="iInstitutionService" class="TDS.Proctor.Services.InstitutionService" scope="prototype">
 		<constructor-arg ref="tdsSettings"/>
      	<constructor-arg ref="iInstitutionRepository"/>
@@ -20,11 +20,11 @@
 	<bean id="iProctorUserService" class="TDS.Proctor.Services.ProctorUserService" scope="prototype">
 		<constructor-arg ref="tdsSettings"/>
      	<constructor-arg ref="iProctorRepository"/>
-	</bean>	
+	</bean>
 	<bean id="legacyTesteeRequestService" class="TDS.Proctor.Services.TesteeRequestService" scope="prototype">
 		<constructor-arg ref="tdsSettings"/>
      	<constructor-arg ref="iTesteeRequestRepository"/>
-	</bean>	
+	</bean>
 	<bean id="iTesteeService" class="TDS.Proctor.Services.TesteeService" scope="prototype">
 		<constructor-arg ref="tdsSettings"/>
      	<constructor-arg ref="iTesteeRepository"/>
@@ -43,14 +43,14 @@
 		<constructor-arg ref="tdsSettings"/>
      	<constructor-arg ref="iTestRepository"/>
 	</bean>
-	
+
 	<bean id="iMessageService" class="TDS.Proctor.Services.MessageService" scope="prototype">
      	<constructor-arg ref="iMessageRepository"/>
-	</bean>	
-	
+	</bean>
+
 	<bean id="proctorAppTasks" class="TDS.Proctor.Services.ProctorAppTasks" scope="prototype">
 		<property name="appConfigTasks"><ref bean="iAppConfigService"/></property>
-		<property name="testOppTasks"><ref bean="iTestOpportunityService"/></property>
+        <property name="testOppTasks"><ref bean="iTestOpportunityService"/></property>
      	<property name="testTasks"><ref bean="iTestService"/></property>
      	<property name="alertTasks"><ref bean="iAlertMessageService"/></property>
      	<property name="requestTasks"><ref bean="iTesteeRequestService"/></property>
@@ -58,13 +58,13 @@
      	<property name="institutionTasks"><ref bean="iInstitutionService"/></property>
      	<property name="proctorUserTasks"><ref bean="iProctorUserService"/></property>
 	</bean>
-	
+
 	<bean id="proctorPackageService" class="TDS.Proctor.Services.remote.RemoteProctorPackageService" />
 
 	<bean id="httpWebHelper" class="AIR.Common.Web.HttpWebHelper"/>
-	
+
 	<bean id="messageXml" class="TDS.Shared.Messages.MessageXml"/>
-	
+
 	<bean id="clientContextBrowserValidation" class="TDS.Proctor.Sql.Data.ClientContextBrowserValidation" scope="singleton" />
 
 </beans>

--- a/proctor/src/test/java/TDS/Proctor/services/RemoteTesteeRequestServiceTest.java
+++ b/proctor/src/test/java/TDS/Proctor/services/RemoteTesteeRequestServiceTest.java
@@ -1,7 +1,278 @@
 package TDS.Proctor.services;
 
-/**
- * Created by emunoz on 3/13/17.
- */
+import TDS.Proctor.Services.remote.RemoteTesteeRequestService;
+import TDS.Proctor.Sql.Data.Abstractions.ExamPrintRequestRepository;
+import TDS.Proctor.Sql.Data.Abstractions.ExamRepository;
+import TDS.Proctor.Sql.Data.Abstractions.ITesteeRequestService;
+import TDS.Proctor.Sql.Data.TesteeRequest;
+import TDS.Proctor.Sql.Data.TesteeRequests;
+import TDS.Proctor.performance.dao.ProctorUserDao;
+import TDS.Shared.Exceptions.ReturnStatusException;
+import org.joda.time.Instant;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import tds.exam.Exam;
+import tds.exam.ExamPrintRequest;
+import tds.exam.ExamPrintRequestStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
 public class RemoteTesteeRequestServiceTest {
+    private RemoteTesteeRequestService service;
+
+    @Mock
+    private ITesteeRequestService legacyTestOpportunityService;
+
+    @Mock
+    private ExamPrintRequestRepository mockExamPrintRequestRepository;
+
+    @Mock
+    private ExamRepository mockExamRepository;
+
+    @Mock
+    private ProctorUserDao proctorUserDao;
+
+    @Before
+    public void setup() {
+        service = new RemoteTesteeRequestService(legacyTestOpportunityService, mockExamPrintRequestRepository, mockExamRepository,
+            false, true, proctorUserDao);
+    }
+
+    @Test(expected = ReturnStatusException.class)
+    public void shouldThrowForAccessDenied() throws Exception {
+        final UUID examId = UUID.randomUUID();
+        final UUID sessionId = UUID.randomUUID();
+        final UUID browserId = UUID.randomUUID();
+        final long proctorId = 2112;
+
+        when(proctorUserDao.validateProctorSession(proctorId, sessionId, browserId)).thenReturn("Invalid");
+        service.getCurrentTesteeRequests(examId, sessionId, proctorId, browserId);
+    }
+
+    @Test
+    public void shouldGetCurrentTesteeRequests() throws Exception {
+        final UUID examId = UUID.randomUUID();
+        final UUID sessionId = UUID.randomUUID();
+        final UUID browserId = UUID.randomUUID();
+        final long proctorId = 2112;
+
+        ExamPrintRequest request1 = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .withSessionId(sessionId)
+            .withStatus(ExamPrintRequestStatus.SUBMITTED)
+            .withExamId(examId)
+            .withParameters("params")
+            .withType(ExamPrintRequest.REQUEST_TYPE_PRINT_ITEM)
+            .withValue("/path/to/resource")
+            .withCreatedAt(Instant.now())
+            .withItemPosition(4)
+            .withPagePosition(2)
+            .withDescription("request 1")
+            .build();
+        ExamPrintRequest request2 = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .withSessionId(sessionId)
+            .withStatus(ExamPrintRequestStatus.SUBMITTED)
+            .withExamId(examId)
+            .withParameters("params")
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
+            .withValue("/path/to/resource")
+            .withCreatedAt(Instant.now())
+            .withItemPosition(0)
+            .withPagePosition(2)
+            .withDescription("request 2")
+            .build();
+
+        when(proctorUserDao.validateProctorSession(proctorId, sessionId, browserId)).thenReturn(null);
+        when(mockExamPrintRequestRepository.findUnfulfilledRequests(examId, sessionId)).thenReturn(Arrays.asList(request1, request2));
+
+        TesteeRequests requests = service.getCurrentTesteeRequests(examId, sessionId, proctorId, browserId);
+        verify(proctorUserDao).validateProctorSession(proctorId, sessionId, browserId);
+        verify(mockExamPrintRequestRepository).findUnfulfilledRequests(examId, sessionId);
+
+        assertThat(requests).hasSize(2);
+        TesteeRequest testeeRequest1 = requests.get(0);
+        assertThat(testeeRequest1.getKey()).isEqualTo(request1.getId());
+        assertThat(testeeRequest1.getDateSubmitted()).isEqualTo(request1.getCreatedAt().toDate());
+        assertThat(testeeRequest1.getItemPage()).isEqualTo(request1.getPagePosition());
+        assertThat(testeeRequest1.getItemPosition()).isEqualTo(request1.getItemPosition());
+        assertThat(testeeRequest1.getOppKey()).isEqualTo(request1.getExamId());
+        assertThat(testeeRequest1.getSessionKey()).isEqualTo(request1.getSessionId());
+        assertThat(testeeRequest1.getRequestType()).isEqualTo(request1.getType());
+        assertThat(testeeRequest1.getRequestValue()).isEqualTo(request1.getValue());
+        assertThat(testeeRequest1.getRequestDesc()).isEqualTo(request1.getDescription());
+        assertThat(testeeRequest1.getDateFulfilled()).isNull();
+
+        TesteeRequest testeeRequest2 = requests.get(1);
+        assertThat(testeeRequest2.getKey()).isEqualTo(request2.getId());
+        assertThat(testeeRequest2.getDateSubmitted()).isEqualTo(request2.getCreatedAt().toDate());
+        assertThat(testeeRequest2.getItemPage()).isEqualTo(request2.getPagePosition());
+        assertThat(testeeRequest2.getItemPosition()).isEqualTo(request2.getItemPosition());
+        assertThat(testeeRequest2.getOppKey()).isEqualTo(request2.getExamId());
+        assertThat(testeeRequest2.getSessionKey()).isEqualTo(request2.getSessionId());
+        assertThat(testeeRequest2.getRequestType()).isEqualTo(request2.getType());
+        assertThat(testeeRequest2.getRequestValue()).isEqualTo(request2.getValue());
+        assertThat(testeeRequest2.getRequestDesc()).isEqualTo(request2.getDescription());
+        assertThat(testeeRequest2.getDateFulfilled()).isNull();
+
+    }
+
+    @Test
+    public void shouldGetApprovedTesteeRequests() throws Exception {
+        final UUID sessionId = UUID.randomUUID();
+        final UUID browserId = UUID.randomUUID();
+        final long proctorId = 2112;
+
+        ExamPrintRequest request = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .withSessionId(sessionId)
+            .withStatus(ExamPrintRequestStatus.APPROVED)
+            .withChangedAt(Instant.now())
+            .withExamId(UUID.randomUUID())
+            .withParameters("params")
+            .withType(ExamPrintRequest.REQUEST_TYPE_PRINT_ITEM)
+            .withValue("/path/to/resource")
+            .withCreatedAt(Instant.now())
+            .withItemPosition(4)
+            .withPagePosition(2)
+            .withDescription("request 1")
+            .build();
+
+        when(proctorUserDao.validateProctorSession(proctorId, sessionId, browserId)).thenReturn(null);
+        when(mockExamPrintRequestRepository.findApprovedRequests(sessionId)).thenReturn(Arrays.asList(request));
+
+        TesteeRequests testeeRequests = service.getApprovedTesteeRequests(sessionId, proctorId, browserId);
+
+        verify(proctorUserDao).validateProctorSession(proctorId, sessionId, browserId);
+        verify(mockExamPrintRequestRepository).findApprovedRequests(sessionId);
+
+        assertThat(testeeRequests).hasSize(1);
+        TesteeRequest testeeRequest = testeeRequests.get(0);
+        assertThat(testeeRequest.getKey()).isEqualTo(request.getId());
+        assertThat(testeeRequest.getDateSubmitted()).isEqualTo(request.getCreatedAt().toDate());
+        assertThat(testeeRequest.getItemPage()).isEqualTo(request.getPagePosition());
+        assertThat(testeeRequest.getItemPosition()).isEqualTo(request.getItemPosition());
+        assertThat(testeeRequest.getOppKey()).isEqualTo(request.getExamId());
+        assertThat(testeeRequest.getSessionKey()).isEqualTo(request.getSessionId());
+        assertThat(testeeRequest.getRequestType()).isEqualTo(request.getType());
+        assertThat(testeeRequest.getRequestValue()).isEqualTo(request.getValue());
+        assertThat(testeeRequest.getRequestDesc()).isEqualTo(request.getDescription());
+        assertThat(testeeRequest.getDateFulfilled()).isEqualTo(request.getChangedAt().toDate());
+    }
+
+    @Test(expected = ReturnStatusException.class)
+    public void shouldThrowForAccessDeniedFindApproved() throws Exception {
+        final UUID sessionId = UUID.randomUUID();
+        final UUID browserId = UUID.randomUUID();
+        final long proctorId = 2112;
+
+        when(proctorUserDao.validateProctorSession(proctorId, sessionId, browserId)).thenReturn("Invalid");
+        service.getApprovedTesteeRequests(sessionId, proctorId, browserId);
+    }
+
+    @Test
+    public void shouldDenyTesteeRequest() throws Exception {
+        final UUID sessionId = UUID.randomUUID();
+        final UUID browserId = UUID.randomUUID();
+        final UUID requestId = UUID.randomUUID();
+        final String reason = "Some reason";
+        final long proctorId = 2112;
+
+        when(proctorUserDao.validateProctorSession(proctorId, sessionId, browserId)).thenReturn(null);
+        boolean isSuccessful = service.denyTesteeRequest(sessionId, proctorId, browserId, requestId, reason);
+        assertThat(isSuccessful).isTrue();
+        verify(mockExamPrintRequestRepository).denyPrintRequest(requestId, reason);
+        verify(proctorUserDao).validateProctorSession(proctorId, sessionId, browserId);
+    }
+
+    @Test(expected = ReturnStatusException.class)
+    public void shouldThrowForAccessDeniedDenyRequest() throws Exception {
+        final UUID sessionId = UUID.randomUUID();
+        final UUID browserId = UUID.randomUUID();
+        final long proctorId = 2112;
+        final UUID requestId = UUID.randomUUID();
+        final String reason = "Some reason";
+
+        when(proctorUserDao.validateProctorSession(proctorId, sessionId, browserId)).thenReturn("Invalid");
+        service.denyTesteeRequest(sessionId, proctorId, browserId, requestId, reason);
+    }
+
+    @Test
+    public void shouldFindTesteeRequestValues() throws ReturnStatusException {
+        final UUID sessionId = UUID.randomUUID();
+        final UUID browserId = UUID.randomUUID();
+        final long proctorId = 2112;
+        final UUID requestId = UUID.randomUUID();
+
+        Exam exam = new Exam.Builder()
+            .withId(UUID.randomUUID())
+            .withLanguageCode("ENU")
+            .withAttempts(3)
+            .withStudentId(2112)
+            .withStudentName("Peter Steele")
+            .withAssessmentId("Assessment ID")
+            .build();
+
+        ExamPrintRequest request = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .withSessionId(sessionId)
+            .withStatus(ExamPrintRequestStatus.APPROVED)
+            .withChangedAt(Instant.now())
+            .withExamId(exam.getId())
+            .withParameters("params")
+            .withType(ExamPrintRequest.REQUEST_TYPE_PRINT_ITEM)
+            .withValue("/path/to/resource")
+            .withCreatedAt(Instant.now())
+            .withItemPosition(4)
+            .withPagePosition(2)
+            .withItemResponse("Response")
+            .withDescription("request 1")
+            .withParameters("request: params;")
+            .build();
+
+        when(proctorUserDao.validateProctorSession(proctorId, sessionId, browserId)).thenReturn(null);
+        when(mockExamPrintRequestRepository.findRequestAndApprove(requestId)).thenReturn(request);
+        when(mockExamRepository.getExamById(exam.getId())).thenReturn(exam);
+
+        TesteeRequest testeeRequest = service.getTesteeRequestValues(sessionId, proctorId, browserId, requestId, true);
+
+        verify(proctorUserDao).validateProctorSession(proctorId, sessionId, browserId);
+        verify(mockExamPrintRequestRepository).findRequestAndApprove(requestId);
+        verify(mockExamRepository).getExamById(exam.getId());
+
+        assertThat(testeeRequest.getKey()).isEqualTo(request.getId());
+        assertThat(testeeRequest.getDateSubmitted()).isEqualTo(request.getCreatedAt().toDate());
+        assertThat(testeeRequest.getItemPage()).isEqualTo(request.getPagePosition());
+        assertThat(testeeRequest.getItemPosition()).isEqualTo(request.getItemPosition());
+        assertThat(testeeRequest.getOppKey()).isEqualTo(request.getExamId());
+        assertThat(testeeRequest.getSessionKey()).isEqualTo(request.getSessionId());
+        assertThat(testeeRequest.getRequestType()).isEqualTo(request.getType());
+        assertThat(testeeRequest.getRequestValue()).isEqualTo(request.getValue());
+        assertThat(testeeRequest.getRequestDesc()).isEqualTo(request.getDescription());
+        assertThat(testeeRequest.getDateFulfilled()).isEqualTo(request.getChangedAt().toDate());
+        assertThat(testeeRequest.getTestID()).isEqualTo(exam.getAssessmentId());
+        assertThat(testeeRequest.getTesteeKey()).isEqualTo(exam.getStudentId());
+        assertThat(testeeRequest.getTesteeName()).isEqualTo(exam.getStudentName());
+        assertThat(testeeRequest.getLanguage()).isEqualTo(exam.getLanguageCode());
+        assertThat(testeeRequest.getAccCode()).isEqualTo(exam.getLanguageCode());
+        assertThat(testeeRequest.getRequestParameters()).isEqualTo(request.getParameters());
+        assertThat(testeeRequest.getOpportunity()).isEqualTo(exam.getAttempts());
+    }
+
+    @Test(expected = ReturnStatusException.class)
+    public void shouldThrowForAccessDeniedGetRequestDetails() throws Exception {
+        final UUID sessionId = UUID.randomUUID();
+        final UUID browserId = UUID.randomUUID();
+        final long proctorId = 2112;
+        final UUID requestId = UUID.randomUUID();
+
+        when(proctorUserDao.validateProctorSession(proctorId, sessionId, browserId)).thenReturn("Invalid");
+        service.getTesteeRequestValues(sessionId, proctorId, browserId, requestId, true);
+    }
 }

--- a/proctor/src/test/java/TDS/Proctor/services/RemoteTesteeRequestServiceTest.java
+++ b/proctor/src/test/java/TDS/Proctor/services/RemoteTesteeRequestServiceTest.java
@@ -1,0 +1,7 @@
+package TDS.Proctor.services;
+
+/**
+ * Created by emunoz on 3/13/17.
+ */
+public class RemoteTesteeRequestServiceTest {
+}

--- a/proctor/src/test/java/TDS/Proctor/sql/RemoteExamPrintRequestRepositoryTest.java
+++ b/proctor/src/test/java/TDS/Proctor/sql/RemoteExamPrintRequestRepositoryTest.java
@@ -1,0 +1,7 @@
+package TDS.Proctor.sql;
+
+/**
+ * Created by emunoz on 3/13/17.
+ */
+public class RemoteExamPrintRequestRepositoryTest {
+}

--- a/proctor/src/test/java/TDS/Proctor/sql/RemoteExamPrintRequestRepositoryTest.java
+++ b/proctor/src/test/java/TDS/Proctor/sql/RemoteExamPrintRequestRepositoryTest.java
@@ -1,7 +1,113 @@
 package TDS.Proctor.sql;
 
-/**
- * Created by emunoz on 3/13/17.
- */
+import TDS.Proctor.Sql.Repository.RemoteExamPrintRequestRepository;
+import TDS.Shared.Exceptions.ReturnStatusException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import tds.exam.ExamPrintRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
 public class RemoteExamPrintRequestRepositoryTest {
+    private RemoteExamPrintRequestRepository repository;
+
+    @Mock
+    private RestTemplate mockRestTemplate;
+
+    @Before
+    public void setup() {
+        ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JodaModule());
+        repository = new RemoteExamPrintRequestRepository(mockRestTemplate, "http://localhost:8080/exam", objectMapper);
+    }
+
+    @Test
+    public void shouldFindUnfulfilledRequests() throws Exception {
+        ExamPrintRequest request = new ExamPrintRequest.Builder(UUID.randomUUID()).build();
+        ResponseEntity<List<ExamPrintRequest>> responseEntity = new ResponseEntity<>(Arrays.asList(request), HttpStatus.OK);
+
+        when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+            .thenReturn(responseEntity);
+
+        assertThat(repository.findUnfulfilledRequests(UUID.randomUUID(), UUID.randomUUID())).containsExactly(request);
+        verify(mockRestTemplate).exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class));
+    }
+
+    @Test(expected = ReturnStatusException.class)
+    public void shouldThrowReturnStatusExceptionWhenRestClientUnhandledExceptionIsThrown() throws ReturnStatusException {
+        when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+            .thenThrow(new RestClientException("Fail"));
+        repository.findUnfulfilledRequests(UUID.randomUUID(), UUID.randomUUID());
+    }
+
+    @Test
+    public void shouldDenyPrintRequest() throws Exception {
+        repository.denyPrintRequest(UUID.randomUUID(), "A reason");
+        verify(mockRestTemplate).exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), eq(Void.class));
+    }
+
+    @Test(expected = ReturnStatusException.class)
+    public void shouldThrowReturnStatusExceptionForRestClientUnhaldnedExceptionDenyPrintRequest() throws Exception {
+        when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), eq(Void.class)))
+            .thenThrow(new RestClientException("Fail"));
+        repository.denyPrintRequest(UUID.randomUUID(), "reason");
+    }
+
+    @Test
+    public void shouldFindRequestAndApprove() throws Exception {
+        ExamPrintRequest request = new ExamPrintRequest.Builder(UUID.randomUUID()).build();
+        when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+            .thenReturn(new ResponseEntity(request, HttpStatus.OK));
+        assertThat(repository.findRequestAndApprove(UUID.randomUUID())).isEqualTo(request);
+        verify(mockRestTemplate).exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class));
+    }
+
+    @Test(expected = ReturnStatusException.class)
+    public void shouldThrowReturnStatusExceptionForRestClientUnhaldnedExceptionFindAndApproveRequests() throws Exception {
+        when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+            .thenThrow(new RestClientException("Fail"));
+        repository.findRequestAndApprove(UUID.randomUUID());
+    }
+
+    @Test
+    public void shouldFindApprovedRequests() throws Exception {
+        ExamPrintRequest request = new ExamPrintRequest.Builder(UUID.randomUUID()).build();
+        ResponseEntity<List<ExamPrintRequest>> responseEntity = new ResponseEntity<>(Arrays.asList(request), HttpStatus.OK);
+
+        when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+            .thenReturn(responseEntity);
+
+        assertThat(repository.findApprovedRequests(UUID.randomUUID())).containsExactly(request);
+        verify(mockRestTemplate).exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class));
+    }
+
+    @Test(expected = ReturnStatusException.class)
+    public void shouldThrowReturnStatusExceptionWhenRestClientUnhandledExceptionIsThrownFindApprovedRequests() throws ReturnStatusException {
+        when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+            .thenThrow(new RestClientException("Fail"));
+        repository.findApprovedRequests(UUID.randomUUID());
+    }
 }

--- a/proctor/src/test/java/TDS/Proctor/sql/RemoteExamPrintRequestRepositoryTest.java
+++ b/proctor/src/test/java/TDS/Proctor/sql/RemoteExamPrintRequestRepositoryTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.UUID;
 
 import tds.exam.ExamPrintRequest;
+import tds.exam.ExpandableExamPrintRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.eq;
@@ -79,9 +80,11 @@ public class RemoteExamPrintRequestRepositoryTest {
     @Test
     public void shouldFindRequestAndApprove() throws Exception {
         ExamPrintRequest request = new ExamPrintRequest.Builder(UUID.randomUUID()).build();
+        ExpandableExamPrintRequest expandableRequest = new ExpandableExamPrintRequest.Builder(request).build();
+
         when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
-            .thenReturn(new ResponseEntity(request, HttpStatus.OK));
-        assertThat(repository.findRequestAndApprove(UUID.randomUUID())).isEqualTo(request);
+            .thenReturn(new ResponseEntity(expandableRequest, HttpStatus.OK));
+        assertThat(repository.findRequestAndApprove(UUID.randomUUID())).isEqualTo(expandableRequest);
         verify(mockRestTemplate).exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class));
     }
 

--- a/proctor/src/test/java/TDS/Proctor/sql/RemoteExamRepositoryTest.java
+++ b/proctor/src/test/java/TDS/Proctor/sql/RemoteExamRepositoryTest.java
@@ -64,7 +64,7 @@ public class RemoteExamRepositoryTest {
         assertThat(remoteExamRepository.findExamsPendingApproval(exam.getSessionId())).isEqualTo(exams);
     }
 
-    @Test (expected = ReturnStatusException.class)
+    @Test(expected = ReturnStatusException.class)
     public void shouldThrowReturnStatusExceptionWhenRestClientUnhandledExceptionIsThrown() throws ReturnStatusException {
         when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
             .thenThrow(new RestClientException("Fail"));
@@ -112,11 +112,26 @@ public class RemoteExamRepositoryTest {
         assertThat(expandableExams).isEmpty();
     }
 
-    @Test (expected = ReturnStatusException.class)
+    @Test(expected = ReturnStatusException.class)
     public void shouldThrowReturnStatusExceptionWhenRestClientUnhandledExceptionIsThrownFindExamsForSession() throws ReturnStatusException {
         when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
             .thenThrow(new RestClientException("Fail"));
         remoteExamRepository.findExamsForSessionId(UUID.randomUUID());
+    }
+
+    @Test
+    public void shouldReturnExamForExamId() throws ReturnStatusException {
+        when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+            .thenReturn(new ResponseEntity(new Exam.Builder().build(), HttpStatus.OK));
+        final Exam exam = remoteExamRepository.getExamById(UUID.randomUUID());
+        assertThat(exam).isNotNull();
+    }
+
+    @Test(expected = ReturnStatusException.class)
+    public void shouldThrowReturnStatusExceptionForRestClientException() throws ReturnStatusException {
+        when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+            .thenThrow(new RestClientException("Fail"));
+        remoteExamRepository.getExamById(UUID.randomUUID());
     }
 }
 

--- a/proctor/src/test/java/TDS/Proctor/sql/RemoteExamRepositoryTest.java
+++ b/proctor/src/test/java/TDS/Proctor/sql/RemoteExamRepositoryTest.java
@@ -123,21 +123,6 @@ public class RemoteExamRepositoryTest {
     }
 
     @Test
-    public void shouldReturnExamForExamId() throws ReturnStatusException {
-        when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
-            .thenReturn(new ResponseEntity(new Exam.Builder().build(), HttpStatus.OK));
-        final Exam exam = remoteExamRepository.getExamById(UUID.randomUUID());
-        assertThat(exam).isNotNull();
-    }
-
-    @Test(expected = ReturnStatusException.class)
-    public void shouldThrowReturnStatusExceptionForRestClientException() throws ReturnStatusException {
-        when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
-            .thenThrow(new RestClientException("Fail"));
-        remoteExamRepository.getExamById(UUID.randomUUID());
-    }
-
-    @Test
     public void shouldPauseAllExamsInASession() throws ReturnStatusException {
         doNothing().when(mockRestTemplate).put(isA(URI.class), isNull());
 


### PR DESCRIPTION
This PR covers Proctor integration for the following print-request related actions:

- Viewing a list of "unfulfilled" print requests
- Approving and fetching additional print request data
- Denying a print request
- Viewing a list of all approved print requests

Most of the logic in the legacy code for these ports is found in the `TesteeRequestRepository` class and the ProctorDLL methods called by that repository.

A few things to note:

- In the "approve and fetch exam print request details" flow, additional data is needed. In particular, data that is part of the Exam itself (such as the student name, student id, exam language, and attempt number) as well as the actual item responses that are stored in our exam_item_response table.
- In this flow there is some additional logic to fetch the item/stimulus path, if the "request value" fetched from legacy `testopprequest` is null. However, this doesn't ever appear to be a possible case, in practice. The student application always seems to send the resource path in the "requestvalue" and it never seems to be null or empty. I have left out this branch of logic in my implementation and I assume the path will always be in `exam_print_request.value`.