### PR TITLE
ProctorPing integration - updating “dateVisited” in session.session v…

### DIFF
--- a/proctor/src/main/java/TDS/Proctor/Services/remote/RemoteSessionService.java
+++ b/proctor/src/main/java/TDS/Proctor/Services/remote/RemoteSessionService.java
@@ -4,7 +4,6 @@ import AIR.Common.Helpers._Ref;
 import TDS.Proctor.Sql.Data.Abstractions.ExamRepository;
 import TDS.Proctor.Sql.Data.Abstractions.ITestSessionService;
 import TDS.Proctor.Sql.Data.Abstractions.SessionRepository;
-import TDS.Proctor.Sql.Data.TestOpps;
 import TDS.Proctor.Sql.Data.TestSession;
 import TDS.Shared.Exceptions.ReturnStatusException;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/proctor/src/main/java/TDS/Proctor/Services/remote/RemoteSessionService.java
+++ b/proctor/src/main/java/TDS/Proctor/Services/remote/RemoteSessionService.java
@@ -4,6 +4,7 @@ import AIR.Common.Helpers._Ref;
 import TDS.Proctor.Sql.Data.Abstractions.ExamRepository;
 import TDS.Proctor.Sql.Data.Abstractions.ITestSessionService;
 import TDS.Proctor.Sql.Data.Abstractions.SessionRepository;
+import TDS.Proctor.Sql.Data.TestOpps;
 import TDS.Proctor.Sql.Data.TestSession;
 import TDS.Shared.Exceptions.ReturnStatusException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -141,7 +142,20 @@ public class RemoteSessionService implements ITestSessionService {
     public boolean setSessionDateVisited(final UUID sessionKey,
                                          final long proctorKey,
                                          final UUID browserKey) throws ReturnStatusException {
-        return legacyTestSessionService.setSessionDateVisited(sessionKey, proctorKey, browserKey);
+        boolean successful = false;
+
+        if (isLegacyCallsEnabled) {
+            successful = legacyTestSessionService.setSessionDateVisited(sessionKey, proctorKey, browserKey);
+        }
+
+        if (!isRemoteCallsEnabled) {
+            return successful;
+        }
+
+        // proctorKey and browserKey are unused - only used for validation, done at the controller level
+        sessionRepository.updateDateVisited(sessionKey);
+
+        return true;
     }
 
     @Override

--- a/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/SessionRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Data/Abstractions/SessionRepository.java
@@ -23,4 +23,11 @@ public interface SessionRepository {
      * @throws ReturnStatusException
      */
     Response<PauseSessionResponse> pause(final UUID sessionId, final PauseSessionRequest request) throws ReturnStatusException;
+
+    /**
+     *  Updates the "date visited" of the session to prevent timeout
+     *
+     * @param sessionId The unique identifier of the {@link tds.session.Session} to extend
+     */
+    void updateDateVisited(UUID sessionId) throws ReturnStatusException;
 }

--- a/proctor/src/main/java/TDS/Proctor/Sql/Repository/RemoteSessionRepository.java
+++ b/proctor/src/main/java/TDS/Proctor/Sql/Repository/RemoteSessionRepository.java
@@ -73,6 +73,26 @@ public class RemoteSessionRepository implements SessionRepository {
         }
     }
 
+    @Override
+    public void updateDateVisited(final UUID sessionId) throws ReturnStatusException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/%s/extend", sessionUrl, sessionId));
+
+        try {
+            restTemplate.exchange(
+                builder.build().toUri(),
+                HttpMethod.PUT,
+                requestHttpEntity,
+                Void.class);
+        } catch (RestClientException rce) {
+            throw new ReturnStatusException(rce);
+        }
+    }
+
     /**
      * Convert the message body from an {@link org.springframework.web.client.HttpClientErrorException} to a
      * {@link tds.common.Response<tds.session.PauseSessionResponse>} to extract the {@link tds.common.ValidationError}.

--- a/proctor/src/test/java/TDS/Proctor/services/RemoteSessionServiceTest.java
+++ b/proctor/src/test/java/TDS/Proctor/services/RemoteSessionServiceTest.java
@@ -284,6 +284,14 @@ public class RemoteSessionServiceTest {
         assertThat(result).isTrue();
     }
 
+    @Test
+    public void shouldUpdateStatus() throws ReturnStatusException {
+        final UUID sessionId = UUID.randomUUID();
+        boolean result = remoteSessionService.setSessionDateVisited(sessionId, 2112, UUID.randomUUID());
+        assertThat(result).isTrue();
+        verify(mockRemoteSessionRepository).updateDateVisited(sessionId);
+    }
+
     @Test(expected = IllegalStateException.class)
     public void shouldThrowIllegalStateExceptionWhenIsLegacyEnabledAndIsRemoteEnabledAreBothFalse() {
         new RemoteSessionService(legacyTestSessionService,

--- a/proctor/src/test/java/TDS/Proctor/sql/RemoteSessionRepositoryTest.java
+++ b/proctor/src/test/java/TDS/Proctor/sql/RemoteSessionRepositoryTest.java
@@ -25,7 +25,9 @@ import tds.session.PauseSessionResponse;
 import tds.session.Session;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -80,5 +82,25 @@ public class RemoteSessionRepositoryTest {
             .thenThrow(new RestClientException("failure"));
 
         remoteSessionRepository.pause(UUID.randomUUID(), new PauseSessionRequest(9L, UUID.randomUUID()));
+    }
+
+    @Test
+    public void shouldExtendSessionSuccessfully() throws ReturnStatusException {
+        UUID sessionId = UUID.randomUUID();
+        remoteSessionRepository.updateDateVisited(sessionId);
+        verify(mockRestTemplate).exchange(isA(URI.class),
+            isA(HttpMethod.class),
+            isA(HttpEntity.class),
+            eq(Void.class));
+    }
+
+    @Test(expected = ReturnStatusException.class)
+    public void shouldThrowReturnStatusExceptionExtendSession() throws ReturnStatusException {
+        when(mockRestTemplate.exchange(isA(URI.class),
+            isA(HttpMethod.class),
+            isA(HttpEntity.class),
+            eq(Void.class)))
+            .thenThrow(new RestClientException("failure"));
+        remoteSessionRepository.updateDateVisited(UUID.randomUUID());
     }
 }


### PR DESCRIPTION
…ia TDS_SessionService

This is the integration piece for the "/ProctorPing" endpoint, which updates the "datevisited" column in session.session. Updating this value prevents inactivity timeout of a session.

Please reference https://jira.fairwaytech.com/browse/TDS-769 for more details.