### PR TITLE
Fix status endpoint

### DIFF
--- a/proctor/pom.xml
+++ b/proctor/pom.xml
@@ -18,7 +18,7 @@
 		<tds-dll.version>3.0.0</tds-dll.version>
 		<progman-client.version>3.0.1</progman-client.version>
 		<sb11-mna-client.version>3.0.0</sb11-mna-client.version>
-		<sb11-shared-code.version>3.0.1</sb11-shared-code.version>
+		<sb11-shared-code.version>3.0.2</sb11-shared-code.version>
 		<sb11-shared-security.version>3.0.0</sb11-shared-security.version>
 		<org.springframework.security-version>3.2.4.RELEASE</org.springframework.security-version>
 		<tds-exam-client.version>0.0.9</tds-exam-client.version>

--- a/proctor/src/main/java/TDS/Proctor/Presentation/LoginPresenter.java
+++ b/proctor/src/main/java/TDS/Proctor/Presentation/LoginPresenter.java
@@ -26,13 +26,11 @@ import TDS.Shared.Security.IEncryption;
 import TDS.Shared.Web.UserCookie;
 import org.apache.commons.lang3.StringUtils;
 import org.opentestsystem.delivery.logging.EventInfo;
-import org.opentestsystem.delivery.logging.EventLogger;
 import org.opentestsystem.delivery.logging.EventParser;
 import org.opentestsystem.delivery.logging.ProctorEventLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.UUID;
 
 import static org.opentestsystem.delivery.logging.EventLogger.Checkpoint.ENTER;
@@ -211,7 +209,11 @@ public class LoginPresenter extends PresenterBase
 
   public boolean doLogout () {
     final ProctorEventLogger _eventLogger = new ProctorEventLogger();
-    final EventInfo eventInfo = EventInfo.create(LOGOUT.name(), ENTER.name(), EventParser.getEventDataFields(getHttpCurrentContext().getRequest()));
+    final EventInfo eventInfo = EventInfo.builder()
+        .event(LOGOUT.name())
+        .checkpoint(ENTER.name())
+        .data(EventParser.getEventDataFields(getHttpCurrentContext().getRequest()))
+        .build();
     _eventLogger.info(eventInfo);
     try {
 

--- a/proctor/src/main/java/TDS/Proctor/Web/presentation/backing/UserDetailsBacking.java
+++ b/proctor/src/main/java/TDS/Proctor/Web/presentation/backing/UserDetailsBacking.java
@@ -8,16 +8,19 @@
  ******************************************************************************/
 package TDS.Proctor.Web.presentation.backing;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.UUID;
-
+import AIR.Common.Utilities.SpringApplicationContext;
+import AIR.Common.Web.CookieHelper;
+import TDS.Proctor.Presentation.IPresenterBase;
+import TDS.Proctor.Presentation.PresenterBase;
+import TDS.Proctor.Presentation.SelectRolePresenter;
+import TDS.Proctor.Sql.Data.Abstractions.IProctorUserService;
+import TDS.Proctor.Sql.Data.ProctorUser;
+import TDS.Proctor.Web.presentation.taglib.CSSLink;
+import TDS.Proctor.Web.presentation.taglib.GlobalJavascript;
+import TDS.Shared.Exceptions.ReturnStatusException;
 import org.opentestsystem.delivery.logging.EventInfo;
 import org.opentestsystem.delivery.logging.EventParser;
 import org.opentestsystem.delivery.logging.ProctorEventLogger;
-import org.opentestsystem.shared.security.domain.SbacPermission;
 import org.opentestsystem.shared.security.domain.SbacRole;
 import org.opentestsystem.shared.security.domain.SbacUser;
 import org.slf4j.Logger;
@@ -25,16 +28,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
-import AIR.Common.Utilities.SpringApplicationContext;
-import AIR.Common.Web.CookieHelper;
-import TDS.Proctor.Presentation.IPresenterBase;
-import TDS.Proctor.Presentation.PresenterBase;
-import TDS.Proctor.Presentation.SelectRolePresenter;
-import TDS.Proctor.Sql.Data.ProctorUser;
-import TDS.Proctor.Sql.Data.Abstractions.IProctorUserService;
-import TDS.Proctor.Web.presentation.taglib.CSSLink;
-import TDS.Proctor.Web.presentation.taglib.GlobalJavascript;
-import TDS.Shared.Exceptions.ReturnStatusException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
 
 import static org.opentestsystem.delivery.logging.EventLogger.Checkpoint.ENTER;
 import static org.opentestsystem.delivery.logging.EventLogger.Checkpoint.EXIT;
@@ -133,7 +131,11 @@ public class UserDetailsBacking extends BasePage implements IPresenterBase
 
   public void init() throws Exception {
     final ProctorEventLogger _eventLogger = new ProctorEventLogger();
-    final EventInfo eventInfo = EventInfo.create(LOGIN.name(), ENTER.name(), EventParser.getEventDataFields(getCurrentContext().getRequest()));
+    final EventInfo eventInfo = EventInfo.builder()
+        .event(LOGIN.name())
+        .checkpoint(ENTER.name())
+        .data(EventParser.getEventDataFields(getCurrentContext().getRequest()))
+        .build();
     _eventLogger.info(eventInfo);
 
     try {

--- a/proctor/src/main/java/org/opentestsystem/delivery/logging/ProctorEventParserFactory.java
+++ b/proctor/src/main/java/org/opentestsystem/delivery/logging/ProctorEventParserFactory.java
@@ -49,7 +49,7 @@ class ProctorParser extends EventParser {
 
   @Override
   public Optional<EventInfo> parsePreHandle(final HttpServletRequest request, final Object handler, final EventLogger logger) {
-    return Optional.of(EventInfo.create(request.getPathInfo(), getEventDataFields(request, handler)));
+    return Optional.of(EventInfo.builder().event(request.getPathInfo()).data(getEventDataFields(request, handler)).build());
   }
 
   @Override


### PR DESCRIPTION
This PR bumps the ss-shared-code dependency version to enable the status endpoint at:
http://localhost:8080/proctor/status
