### PR TITLE
Add loadbalancer saml support

### DIFF
--- a/proctor/pom.xml
+++ b/proctor/pom.xml
@@ -358,7 +358,7 @@
                             Modify as required. -->
                         <resource>
                             <targetPath>/</targetPath>
-                            <directory>/opt/sbtds/deploy/resources</directory>
+                            <directory>/opt/sbtds/awsqa/resources</directory>
                             <include>security/**/*</include>
                         </resource>
                     </resources>

--- a/proctor/pom.xml
+++ b/proctor/pom.xml
@@ -358,7 +358,7 @@
                             Modify as required. -->
                         <resource>
                             <targetPath>/</targetPath>
-                            <directory>/opt/sbtds/awsqa/resources</directory>
+                            <directory>/opt/sbtds/deploy/resources</directory>
                             <include>security/**/*</include>
                         </resource>
                     </resources>

--- a/proctor/src/main/java/TDS/Proctor/configuration/SAMLConfiguration.java
+++ b/proctor/src/main/java/TDS/Proctor/configuration/SAMLConfiguration.java
@@ -1,0 +1,39 @@
+package TDS.Proctor.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.saml.context.SAMLContextProvider;
+import org.springframework.security.saml.context.SAMLContextProviderImpl;
+import org.springframework.security.saml.context.SAMLContextProviderLB;
+
+import javax.servlet.ServletException;
+
+/**
+ * This configuration is responsible for providing SAML Configurations.
+ */
+@Configuration
+public class SAMLConfiguration {
+
+    @Bean
+    public SAMLContextProvider contextProvider(
+        @Value("${spring.saml.loadBalanced:false}") final boolean loadBalanced,
+        @Value("${spring.saml.scheme:https}") final String scheme,
+        @Value("${spring.saml.serverName}") final String serverName,
+        @Value("${spring.saml.contextPath:/proctor}") final String contextPath,
+        @Value("${spring.saml.serverPort:0}") final int serverPort,
+        @Value("${spring.saml.includeServerPort:false}") final boolean includePort) throws ServletException {
+        if (!loadBalanced) {
+            return new SAMLContextProviderImpl();
+        }
+
+        final SAMLContextProviderLB contextProvider = new SAMLContextProviderLB();
+        contextProvider.setScheme(scheme);
+        contextProvider.setServerName(serverName);
+        contextProvider.setContextPath(contextPath);
+        contextProvider.setServerPort(serverPort);
+        contextProvider.setIncludeServerPortInRequestURL(includePort);
+
+        return contextProvider;
+    }
+}

--- a/proctor/src/main/resources/root-context.xml
+++ b/proctor/src/main/resources/root-context.xml
@@ -43,6 +43,7 @@
 	
 	<context:annotation-config />
 
+	<context:component-scan base-package="TDS.Proctor.configuration"/>
 	<context:component-scan base-package="tds.dll.common.performance"/>
 	<context:component-scan base-package="TDS.Proctor.performance"/>
 	<context:component-scan base-package="tds.dll.common.diagnostic"/>

--- a/proctor/src/main/resources/security/samlmetadata-context.xml
+++ b/proctor/src/main/resources/security/samlmetadata-context.xml
@@ -9,12 +9,7 @@
               http://www.springframework.org/schema/security/spring-security-3.2.xsd 
               http://www.springframework.org/schema/context 
               http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-       
-    <bean id="contextProvider" class="org.springframework.security.saml.context.SAMLContextProviderImpl">
-     
-    </bean>
 
-    
         <bean id="metadataDelegate" class="org.springframework.security.saml.metadata.ExtendedMetadataDelegate">
     <constructor-arg>
         <bean class="org.opensaml.saml2.metadata.provider.FilesystemMetadataProvider">


### PR DESCRIPTION
The previous SAMLContextProviderImpl cannot account for SSL termination at a LoadBalancer implementation.
This change leaves the default implementation alone, but allows for configuring a SAMLContextProviderLB using spring properties.