### PR TITLE
Fixes spring sleuth malformed id exception

### DIFF
--- a/proctor/pom.xml
+++ b/proctor/pom.xml
@@ -18,7 +18,7 @@
 		<tds-dll.version>3.0.0</tds-dll.version>
 		<progman-client.version>3.0.1</progman-client.version>
 		<sb11-mna-client.version>3.0.0</sb11-mna-client.version>
-		<sb11-shared-code.version>3.0.10</sb11-shared-code.version>
+		<sb11-shared-code.version>3.0.11</sb11-shared-code.version>
 		<sb11-shared-security.version>3.0.0</sb11-shared-security.version>
 		<org.springframework.security-version>3.2.4.RELEASE</org.springframework.security-version>
 		<tds-exam-client.version>0.0.18</tds-exam-client.version>


### PR DESCRIPTION
Fixes java.lang.IllegalArgumentException: Malformed id:
org.springframework.cloud.sleuth.Span.hexToId(Span.java:575)