### PR TITLE
SessionDTO and others were being sent as xml instead of json

### DIFF
--- a/proctor/src/main/java/TDS/Proctor/Web/Handlers/ActiveSessionXHR.java
+++ b/proctor/src/main/java/TDS/Proctor/Web/Handlers/ActiveSessionXHR.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -74,6 +75,7 @@ import static org.opentestsystem.delivery.logging.ProctorEventLogger.ProctorEven
 
 @Scope ("prototype")
 @Controller
+@RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
 public class ActiveSessionXHR extends HttpHandlerBase
 {
 private static final Logger _logger = LoggerFactory.getLogger(ActiveSessionXHR.class);


### PR DESCRIPTION
Explicitly returning json from endpoints