### PR TITLE
Updating EmbossRequest with content repository call

### DIFF
--- a/proctor/pom.xml
+++ b/proctor/pom.xml
@@ -248,6 +248,11 @@
 			<version>2.6.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>compile</scope>
+		</dependency>
 		<!-- Start JSF integration -->
 		<!-- Mojara implementation of JSF -->
 		<!-- dependency> <groupId>org.glassfish</groupId> <artifactId>javax.faces</artifactId> <version>${javax.faces-version}</version> <scope>runtime</scope> </dependency> <dependency> <groupId>org.glassfish</groupId> 

--- a/proctor/src/main/java/TDS/Proctor/Services/EmbossFileService.java
+++ b/proctor/src/main/java/TDS/Proctor/Services/EmbossFileService.java
@@ -14,23 +14,31 @@
 package TDS.Proctor.Services;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.util.ByteArrayBuffer;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+
+import tds.itemrenderer.repository.ContentRepository;
 
 @Component
 public class EmbossFileService {
+
+
+    private final ContentRepository contentRepository;
+
     // 13 = carriage return
     // 10 = new line
     // 12 = form feed (new page)
     private static final char[] PAGE_BREAK_CHARS = {(char)13, (char)10, (char)12};
     static byte[] PAGE_BREAK_BYTES = null;
 
-    public EmbossFileService() {
+    @Autowired
+    public EmbossFileService(final ContentRepository contentRepository) {
+        this.contentRepository = contentRepository;
         String pageBreak = new String(PAGE_BREAK_CHARS);
 
         try {
@@ -51,14 +59,14 @@ public class EmbossFileService {
     public byte[] combineFiles(String[] files) throws IOException {
         ByteArrayBuffer contents = new ByteArrayBuffer(0);
 
-        byte[] bytes = Files.readAllBytes(Paths.get(files[0]));
+        byte[] bytes = IOUtils.toByteArray(contentRepository.findResource(files[0]));
         contents.append(bytes, 0, bytes.length);
 
         for (int i = 1; i < files.length; i++) {
             // page break
             contents.append(PAGE_BREAK_BYTES, 0, PAGE_BREAK_BYTES.length);
 
-            bytes = Files.readAllBytes(Paths.get(files[i]));
+            bytes = IOUtils.toByteArray(contentRepository.findResource(files[i]));
             contents.append(bytes, 0, bytes.length);
         }
 

--- a/proctor/src/main/java/TDS/Proctor/Web/presentation/backing/EmbossRequest.java
+++ b/proctor/src/main/java/TDS/Proctor/Web/presentation/backing/EmbossRequest.java
@@ -33,12 +33,16 @@ import TDS.Proctor.Presentation.IPrintRequestPresenterView;
 import TDS.Proctor.Presentation.PresenterBase;
 import TDS.Proctor.Presentation.PrintRequestPresenter;
 import TDS.Proctor.Sql.Data.TesteeRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
 /**
  * @author mskhan
  * 
  */
-
+@Component
+@Scope("request")
 public class EmbossRequest extends BasePage implements IPrintRequestPresenterView
 {
 
@@ -51,7 +55,8 @@ public class EmbossRequest extends BasePage implements IPrintRequestPresenterVie
   private String                _lblDate;
   private PageLayout            _pageLayout;
   private String                _title;
-  private EmbossFileService     _embossFileService = new EmbossFileService();
+  @Autowired
+  private EmbossFileService     _embossFileService;
 
   public void download (String filepath, String contentType, String contentDisposition) throws IOException {
     String[] files = filepath.split(";");
@@ -122,7 +127,7 @@ public class EmbossRequest extends BasePage implements IPrintRequestPresenterVie
     {
       writeError (ex.getMessage ());
       // handle the message first
-      // TDSLogger.Application.Fatal(ex);
+      // TDSLogger.Application.Fatal (ex);
       return;
     }
   }

--- a/proctor/src/main/resources/root-context.xml
+++ b/proctor/src/main/resources/root-context.xml
@@ -43,7 +43,7 @@
 	<context:component-scan base-package="TDS.Proctor.performance"/>
 	<context:component-scan base-package="tds.dll.common.diagnostic"/>
 	<context:component-scan base-package="TDS.Proctor.diagnostic"/>
-
+	<context:component-scan base-package="TDS.Proctor.Web.presentation.backing"/>
 	<context:component-scan base-package="TDS.Proctor.Services"/>
 	<context:component-scan base-package="tds.itemrenderer.repository" />
 

--- a/proctor/src/test/java/org/air/services/test/EmbossFileServiceTest.java
+++ b/proctor/src/test/java/org/air/services/test/EmbossFileServiceTest.java
@@ -21,20 +21,17 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.when;
-
-import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import tds.itemrenderer.repository.ContentRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EmbossFileServiceTest {


### PR DESCRIPTION
Fixing two issues here:

https://jira.fairwaytech.com/browse/TDS-1179
The lack of the spring-test as a compile-time dependency was causing a NoClassDefFoundError when attempting to approve a print request. Given more time, we'd remove the need to pull in a test dependency into production code, but for the sake of time I've added the compile time dependency on spring-test.

https://jira.fairwaytech.com/browse/TDS-1179 
EmbossService was still fetching content data from disk. Updated this code to utilize the RemoteContentRepository.