### PR TITLE
Updating customized error message when student cancels approval request

### DIFF
--- a/proctor/src/main/java/TDS/Proctor/Services/remote/RemoteTestOpportunityService.java
+++ b/proctor/src/main/java/TDS/Proctor/Services/remote/RemoteTestOpportunityService.java
@@ -197,6 +197,13 @@ public class RemoteTestOpportunityService implements ITestOpportunityService {
 
         //Consistent with the legacy implementation.  If it fails for any reason it throws.
         if(maybeError.isPresent()) {
+            if (maybeError.get().getCode().equals("badStatusTransition")) {
+                // See TestSessionServiceImpl.java line 388 - failed update status call should result in a customized message.
+                final String error = "This student is no longer awaiting approval.";
+                LOG.warn("Unable to approve opportunity: {}", error);
+                throw new ReturnStatusException(error);
+            }
+
             LOG.warn("Unable to approve opportunity: {}", maybeError.get().getMessage());
             throw new ReturnStatusException(maybeError.get().getMessage());
         }


### PR DESCRIPTION
Adding custom error message in case where student cancels assessment approval request right before proctor approves request.

Ideally this custom error message would be built into the updateStatus api call. However, this call is specific to the proctor application, and student is the primary caller of /updateStatus in almost every other case.